### PR TITLE
Router: single-jq-pass perf (~10x) + world-class README diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,26 @@ The single biggest lever on agent cost is **which model does which job** — tok
 
 You don't have to think about it — delegation happens automatically. When you want control, `/cost` re-plans a task into the cheapest-correct mix before you spend, and `compass route "<task>"` picks a tier deterministically (now **scored against a labeled eval set and gated in CI**). Every autonomous step is hard-capped by budget, and `compass spend` / `compass impact` show you exactly where the money went and what you saved. → [Cost & models](docs/02-cost-and-models.md)
 
+**The router is a standalone, reusable module** ([`router/`](router/)) — a three-layer cascade that pays for intelligence only where it's needed: a free keyword heuristic answers the confident majority, an optional local classifier mops up most of the rest for free, and a Haiku LLM judge is consulted only on the genuinely ambiguous tail. Default routing is the heuristic alone (zero network); layers ②/③ are opt-in.
+
+```mermaid
+flowchart LR
+    T(["📝 task"]) --> H{"① heuristic<br/>keywords · 0ms · free"}
+    H -- "confident · ~80%" --> OUT(["🎯 tier<br/>haiku · sonnet · opus"])
+    H -- "ambiguous" --> C{"② classifier<br/>local · ~1ms · free<br/>(opt-in)"}
+    C -- "confident" --> OUT
+    C -- "abstains / off" --> J["③ LLM judge<br/>Haiku · ~300ms · $"]
+    J --> OUT
+    classDef free fill:#dcfce7,stroke:#16a34a,color:#14532d;
+    classDef paid fill:#fef9c3,stroke:#ca8a04,color:#713f12;
+    classDef io   fill:#e0f2fe,stroke:#0284c7,color:#075985;
+    class H,C free
+    class J paid
+    class T,OUT io
+```
+
+<sub>Measured: ~61% cheaper than all-opus at ~98% quality-retention on a fair task mix; the cascade lifts the ambiguous tail where pure keyword routing under-serves. → [`router/README.md`](router/README.md)</sub>
+
 <div align="right"><a href="#contents">↑ top</a></div>
 
 ---

--- a/router/README.md
+++ b/router/README.md
@@ -10,6 +10,34 @@ agent loop: microsecond, offline, deterministic, auditable. Per RouterBench, tra
 only modestly beat trivial baselines on a realistic mix — so a good keyword+length heuristic
 captures most of the savings with none of the latency/cost/dependency.
 
+```mermaid
+flowchart LR
+    T(["📝 task"]) --> H
+
+    H{"① heuristic<br/>keywords · 0ms · free"}
+    C{"② classifier<br/>local NB · ~1ms · free<br/>(opt-in)"}
+    J["③ LLM judge<br/>Haiku · ~300ms · $"]
+    OUT(["🎯 tier<br/>haiku · sonnet · opus"])
+
+    H -- "confident · ~80%" --> OUT
+    H -- "ambiguous" --> C
+    C -- "confident" --> OUT
+    C -- "abstains / off" --> J
+    J --> OUT
+
+    classDef free fill:#dcfce7,stroke:#16a34a,color:#14532d;
+    classDef paid fill:#fef9c3,stroke:#ca8a04,color:#713f12;
+    classDef io   fill:#e0f2fe,stroke:#0284c7,color:#075985;
+    class H,C free
+    class J paid
+    class T,OUT io
+```
+
+> **Pay for intelligence only where it's needed.** The free heuristic answers the confident
+> majority in microseconds; the optional local classifier mops up most of the rest for free;
+> the LLM judge is consulted only on the genuinely ambiguous tail. Layers ②/③ are opt-in —
+> default routing is layer ① alone (zero network).
+
 ## The reusable asset is `router.json`
 
 Everything routing-specific lives in [`router.json`](router.json) — tiers (rank + relative
@@ -114,9 +142,18 @@ cost math applies and the same floors gate it (just off the CI path).
 
 ## Knobs (v1.1)
 
-The full pipeline is: **decide(tier) → confidence → length-rules → bias → escalation → clamps → domain.**
-With no flags it reproduces v1.0 exactly (`strategy: first-match`, `bias: balanced`, escalation off,
-clamps no-op). Each knob has a spec default and a CLI/env override.
+The full pipeline — with no flags it reproduces v1.0 exactly (`strategy: first-match`,
+`bias: balanced`, escalation off, clamps no-op). Each stage is a knob with a spec default
+and a CLI/env override:
+
+```mermaid
+flowchart LR
+    A["decide<br/>(strategy)"] --> B["confidence"] --> C["length<br/>rules"] --> D["bias<br/>(cheap/quality)"] --> E["escalation<br/>(cascade)"] --> F["clamps<br/>(floor/ceiling)"] --> G["domain"] --> R(["tier<br/>(+domain)"])
+    classDef s  fill:#eef2ff,stroke:#6366f1,color:#312e81;
+    classDef io fill:#e0f2fe,stroke:#0284c7,color:#075985;
+    class A,B,C,D,E,F,G s
+    class R io
+```
 
 | Knob | Flag / env | What it does |
 |------|-----------|--------------|
@@ -178,6 +215,18 @@ route.sh --escalate-below 75 --fallback "$PWD/fallback-cascade.sh" "<task>"
 classifier **on** (`ROUTER_CLASSIFIER=on` or `classifier.enabled=true`). Now the classifier
 handles most of the middle for free and the LLM is called only on what the classifier itself
 is unsure about.
+
+```mermaid
+flowchart LR
+    LOG["🧾 --log<br/>route decisions"] --> JUDGE["🧠 LLM judge<br/>labels the ambiguous"]
+    JUDGE --> TRAIN["⚙️ train-classifier.sh<br/>distill labels"]
+    TRAIN --> MODEL["📦 local model"]
+    MODEL --> ON["✅ classifier ON"]
+    ON --> SAVE["💸 fewer LLM calls<br/>cheaper · faster"]
+    SAVE -. "more traffic, more labels" .-> LOG
+    classDef n fill:#f0fdfa,stroke:#0d9488,color:#134e4a;
+    class LOG,JUDGE,TRAIN,MODEL,ON,SAVE n
+```
 
 **When to flip it on:** not before you have data and the per-call LLM cost/latency is the
 bottleneck. For a 3-way tier decision the classifier's *accuracy* edge over the Haiku judge is

--- a/router/route.sh
+++ b/router/route.sh
@@ -15,6 +15,9 @@
 #   --profile NAME                              --floor TIER  --ceiling TIER  --allow t1,t2
 #   --escalate-below N  --fallback "CMD"        --local FILE   --spec FILE   --log FILE
 # Env: COMPASS_ROUTE_BIAS, COMPASS_ROUTER_SPEC.  The SPEC (router.json) is the reusable asset.
+#
+# PERF: the whole spec is read in ONE jq pass into shell vars/arrays; the per-route hot path
+# then uses pure-bash lookups + the grep matches that regex routing inherently needs.
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SPEC="${COMPASS_ROUTER_SPEC:-$HERE/router.json}"; LOCAL=""
@@ -48,67 +51,106 @@ done
 command -v jq >/dev/null || { echo "route: jq required (other languages parse router.json natively)" >&2; exit 2; }
 [ -f "$SPEC" ] || { echo "route: spec not found: $SPEC" >&2; exit 2; }
 
-# ── load spec (+ optional local overlay: local rules take priority, scalars override) ──
+# ── load spec (+ optional local overlay) and dump EVERYTHING in ONE jq pass ───────
 [ -z "$LOCAL" ] && [ -f "$HERE/router.local.json" ] && LOCAL="$HERE/router.local.json"
-EFFSPEC="$(mktemp)"; trap 'rm -f "$EFFSPEC"' EXIT
 if [ -n "$LOCAL" ] && [ -f "$LOCAL" ]; then
-  jq -s '(.[0] * .[1]) | .rules = (((.[1].rules) // []) + ((.[0].rules) // [])) ' "$SPEC" "$LOCAL" 2>/dev/null \
-    > "$EFFSPEC" || jq '.' "$SPEC" > "$EFFSPEC"
-  # the * merge above loses base.rules ordering ref; recompute cleanly:
-  jq -s '.[0] as $b | .[1] as $l | ($b * $l) | .rules = (($l.rules // []) + ($b.rules // []))' "$SPEC" "$LOCAL" > "$EFFSPEC"
+  MERGED="$(jq -s '.[0] as $b | .[1] as $l | ($b * $l) | .rules = (($l.rules // []) + ($b.rules // []))' "$SPEC" "$LOCAL")"
 else
-  cp "$SPEC" "$EFFSPEC"
+  MERGED="$(cat "$SPEC")"
 fi
-SPEC="$EFFSPEC"
-jqr() { jq -r "$1" "$SPEC"; }
+# Single jq pass → tab-joined typed rows. join("\t") (NOT @tsv) keeps backslashes in
+# patterns intact (\bauth\b). Tiers/rules emitted in rank order.
+DUMP="$(printf '%s' "$MERGED" | jq -r --arg p "$PROFILE" '
+  . as $root
+  | ([ ["S","strategy",(.strategy // "first-match")],
+       ["S","bias",(.bias // "balanced")],
+       ["S","default",.default],
+       ["S","floor",(.clamps.floor // "")],
+       ["S","ceiling",(.clamps.ceiling // "")],
+       ["S","allow",((.clamps.allow // []) | join(","))],
+       ["S","escalate",((.escalation.threshold // 0)|tostring)],
+       ["S","fallback",(.escalation.fallback // "")],
+       ["S","maxrank",(([.tiers[].rank]|max)|tostring)] ]
+     + (.tiers | to_entries | sort_by(.value.rank)
+        | map(["T", .key, (.value.rank|tostring),
+               (($root.profiles[$p][.key].cost  // .value.cost)|tostring),
+               ($root.profiles[$p][.key].model // .value.model)]))
+     + (.rules | map(["R", .tier, .pattern, (.reason // ""), (.unless // ""), ((.weight // 1)|tostring)]))
+     + ((.length_rules // []) | map(["L", (.min_words|tostring), .at_least]))
+     + ((.domains // []) | map(["D", .domain, .pattern])) )
+  | .[] | join("\t")
+')"
 
-# ── resolve knobs (CLI > env > spec default) ──────────────────────────────────
-STRATEGY="${STRATEGY:-$(jqr '.strategy // "first-match"')}"
-BIAS="${BIAS:-${COMPASS_ROUTE_BIAS:-$(jqr '.bias // "balanced"')}}"
-DEFAULT_TIER="$(jqr '.default')"
-[ -n "$FLOOR" ]   || FLOOR="$(jqr '.clamps.floor // empty')"
-[ -n "$CEILING" ] || CEILING="$(jqr '.clamps.ceiling // empty')"
-[ -n "$ALLOW" ]   || ALLOW="$(jqr '((.clamps.allow // []) | join(","))')"
-[ -n "$ESCALATE" ] || ESCALATE="$(jqr '.escalation.threshold // 0')"
-[ -n "$FALLBACK" ] || FALLBACK="$(jqr '.escalation.fallback // empty')"
-MAXRANK="$(jqr '[.tiers[].rank] | max')"
-LOWTIER="$(jq -r '.tiers | to_entries | min_by(.value.rank) | .key' "$SPEC")"
+# ── parse the dump into shell state (pure bash, no further subprocesses) ──────────
+S_strategy=""; S_bias=""; S_default=""; S_floor=""; S_ceiling=""; S_allow=""; S_escalate="0"; S_fallback=""; S_maxrank="0"
+TIER_META=(); TIERS_ORDERED=""; RULES=(); LENGTHS=(); DOMAINS=()
+while IFS=$'\t' read -r typ f1 f2 f3 f4 f5; do
+  case "$typ" in
+    S) case "$f1" in
+         strategy) S_strategy="$f2" ;; bias) S_bias="$f2" ;; default) S_default="$f2" ;;
+         floor) S_floor="$f2" ;; ceiling) S_ceiling="$f2" ;; allow) S_allow="$f2" ;;
+         escalate) S_escalate="$f2" ;; fallback) S_fallback="$f2" ;; maxrank) S_maxrank="$f2" ;;
+       esac ;;
+    T) TIER_META+=("$f1 $f2 $f3 $f4"); TIERS_ORDERED="$TIERS_ORDERED $f1" ;;
+    R) RULES+=("$f1"$'\t'"$f2"$'\t'"$f3"$'\t'"$f4"$'\t'"$f5") ;;
+    L) LENGTHS+=("$f1 $f2") ;;
+    D) DOMAINS+=("$f1"$'\t'"$f2") ;;
+  esac
+done <<EOF
+$DUMP
+EOF
+TIERS_ORDERED="${TIERS_ORDERED# }"
+LOWTIER="${TIERS_ORDERED%% *}"
 
-rank_of()      { jq -r --arg t "$1" '.tiers[$t].rank // 0' "$SPEC"; }
-tier_of_rank() { jq -r --argjson r "$1" 'first(.tiers | to_entries[] | select(.value.rank==$r) | .key) // empty' "$SPEC"; }
-cost_of()      { jq -r --arg t "$1" --arg p "$PROFILE" '(.profiles[$p][$t].cost  // .tiers[$t].cost)'  "$SPEC"; }
-model_of()     { jq -r --arg t "$1" --arg p "$PROFILE" '(.profiles[$p][$t].model // .tiers[$t].model)' "$SPEC"; }
-tier_pattern() { jq -r --arg t "$1" '[.rules[] | select(.tier==$t) | .pattern] | .[0] // ""' "$SPEC"; }
+# resolve knobs: CLI flag > env > spec default
+STRATEGY="${STRATEGY:-$S_strategy}"
+BIAS="${BIAS:-${COMPASS_ROUTE_BIAS:-$S_bias}}"
+DEFAULT_TIER="$S_default"
+[ -n "$FLOOR" ]    || FLOOR="$S_floor"
+[ -n "$CEILING" ]  || CEILING="$S_ceiling"
+[ -n "$ALLOW" ]    || ALLOW="$S_allow"
+[ -n "$ESCALATE" ] || ESCALATE="$S_escalate"
+[ -n "$FALLBACK" ] || FALLBACK="$S_fallback"
+MAXRANK="$S_maxrank"
 
-TIERS_ORDERED="$(jq -r '.tiers | to_entries | sort_by(.value.rank) | .[].key' "$SPEC" | tr '\n' ' ')"
+# pure-bash metadata lookups over TIER_META ("tier rank cost model")
+rank_of()      { local t="$1" e; for e in "${TIER_META[@]}"; do case "$e" in "$t "*) set -- $e; printf '%s' "$2"; return;; esac; done; printf '0'; }
+cost_of()      { local t="$1" e; for e in "${TIER_META[@]}"; do case "$e" in "$t "*) set -- $e; printf '%s' "$3"; return;; esac; done; }
+model_of()     { local t="$1" e; for e in "${TIER_META[@]}"; do case "$e" in "$t "*) set -- $e; printf '%s' "$4"; return;; esac; done; }
+tier_of_rank() { local n="$1" e; for e in "${TIER_META[@]}"; do set -- $e; [ "$2" = "$n" ] && { printf '%s' "$1"; return; }; done; }
+tier_pattern() { local t="$1" r rest; for r in "${RULES[@]}"; do case "$r" in "$t"$'\t'*) rest="${r#*$'\t'}"; printf '%s' "${rest%%$'\t'*}"; return;; esac; done; }
+
 LC="$(printf '%s' "$TASK" | tr '[:upper:]' '[:lower:]')"
-DELIM=$'\t'
-
-rules_stream() { jq -r '.rules[] | [.tier, .pattern, (.reason // ""), (.unless // ""), ((.weight // 1)|tostring)] | join("\t")' "$SPEC"; }
 
 # ── stage 1: decide a tier ────────────────────────────────────────────────────
 MATCH_TIER=""; MATCH_REASON=""
 decide_first_match() {
-  local tier pat reason unl w
-  while IFS="$DELIM" read -r tier pat reason unl w; do
+  local r tier pat reason unl
+  for r in "${RULES[@]}"; do
+    IFS=$'\t' read -r tier pat reason unl _ <<EOF
+$r
+EOF
     [ -n "$tier" ] || continue
     printf '%s' "$LC" | grep -qE -- "$pat" || continue
     [ -n "$unl" ] && printf '%s' "$LC" | grep -qE -- "$unl" && continue
     MATCH_TIER="$tier"; MATCH_REASON="$reason"; return 0
-  done < <(rules_stream)
+  done
   MATCH_TIER="$DEFAULT_TIER"; MATCH_REASON="no rule matched — default"
 }
 decide_scored() {  # $1 = hits|weighted
-  local mode="$1" cand tier pat reason unl w kh s best="$DEFAULT_TIER" bestscore=0
+  local mode="$1" cand r tier pat unl w kh s best="$DEFAULT_TIER" bestscore=0
   for cand in $TIERS_ORDERED; do
     s=0
-    while IFS="$DELIM" read -r tier pat reason unl w; do
+    for r in "${RULES[@]}"; do
+      IFS=$'\t' read -r tier pat _ unl w <<EOF
+$r
+EOF
       [ "$tier" = "$cand" ] || continue
       printf '%s' "$LC" | grep -qE -- "$pat" || continue
       [ -n "$unl" ] && printf '%s' "$LC" | grep -qE -- "$unl" && continue
-      kh="$({ printf '%s' "$LC" | grep -oE -- "$pat" | grep -c . ; } 2>/dev/null || echo 0)"  # KEYWORD hits, not rule count
+      kh="$({ printf '%s' "$LC" | grep -oE -- "$pat" | grep -c . ; } 2>/dev/null || echo 0)"
       if [ "$mode" = weighted ]; then s=$((s + kh * w)); else s=$((s + kh)); fi
-    done < <(rules_stream)
+    done
     if [ "$s" -gt "$bestscore" ]; then best="$cand"; bestscore="$s"
     elif [ "$s" -eq "$bestscore" ] && [ "$s" -gt 0 ] && [ "$(rank_of "$cand")" -gt "$(rank_of "$best")" ]; then best="$cand"; fi
   done
@@ -135,18 +177,20 @@ fi
 [ "$CONFIDENCE" -gt 99 ] && CONFIDENCE=99
 
 # ── stage 3: length rules (raise the floor for long tasks) ────────────────────
-while IFS="$DELIM" read -r minw atleast; do
-  [ -n "$minw" ] || continue
-  if [ "$WORDS" -ge "$minw" ] && [ "$(rank_of "$MATCH_TIER")" -lt "$(rank_of "$atleast")" ]; then
-    MATCH_TIER="$atleast"; MATCH_REASON="$MATCH_REASON; len>=$minw->>=$atleast"
-  fi
-done < <(jq -r '(.length_rules // [])[] | [((.min_words)|tostring), .at_least] | join("\t")' "$SPEC")
+if [ "${#LENGTHS[@]}" -gt 0 ]; then
+  for lr in "${LENGTHS[@]}"; do
+    set -- $lr; minw="$1"; atleast="$2"
+    if [ "$WORDS" -ge "$minw" ] && [ "$(rank_of "$MATCH_TIER")" -lt "$(rank_of "$atleast")" ]; then
+      MATCH_TIER="$atleast"; MATCH_REASON="$MATCH_REASON; len>=$minw->>=$atleast"
+    fi
+  done
+fi
 
 # ── stage 4: bias (nudge only weak picks) ─────────────────────────────────────
 if [ "$CONFIDENCE" -lt 55 ]; then
   r="$(rank_of "$MATCH_TIER")"
   case "$BIAS" in
-    cheap)   [ "$r" -gt 1 ]        && { MATCH_TIER="$(tier_of_rank $((r-1)))"; MATCH_REASON="$MATCH_REASON; bias=cheap->$MATCH_TIER"; } ;;
+    cheap)   [ "$r" -gt 1 ]          && { MATCH_TIER="$(tier_of_rank $((r-1)))"; MATCH_REASON="$MATCH_REASON; bias=cheap->$MATCH_TIER"; } ;;
     quality) [ "$r" -lt "$MAXRANK" ] && { MATCH_TIER="$(tier_of_rank $((r+1)))"; MATCH_REASON="$MATCH_REASON; bias=quality->$MATCH_TIER"; } ;;
   esac
 fi
@@ -177,11 +221,14 @@ fi
 
 # ── stage 7: domain (optional second axis) ────────────────────────────────────
 DOMAIN=""
-if [ "$WANT_DOMAIN" = 1 ]; then
-  while IFS="$DELIM" read -r d pat; do
-    [ -n "$d" ] || continue
-    printf '%s' "$LC" | grep -qE -- "$pat" && { DOMAIN="$d"; break; }
-  done < <(jq -r '(.domains // [])[] | [.domain, .pattern] | join("\t")' "$SPEC")
+if [ "$WANT_DOMAIN" = 1 ] && [ "${#DOMAINS[@]}" -gt 0 ]; then
+  for d in "${DOMAINS[@]}"; do
+    IFS=$'\t' read -r dom pat <<EOF
+$d
+EOF
+    [ -n "$dom" ] || continue
+    printf '%s' "$LC" | grep -qE -- "$pat" && { DOMAIN="$dom"; break; }
+  done
 fi
 
 # ── telemetry + output ────────────────────────────────────────────────────────


### PR DESCRIPTION
Two changes to the `router/` module.

## perf: one jq pass (route.sh ~10× faster suite)
`route.sh` made ~15 `jq` calls per route (scalars, per-tier rank/cost/model, rules, length/domains, lookups). Now a **single jq pass** dumps everything as tab-joined typed rows (`join("\t")`, not `@tsv`, so `\b` patterns survive), parsed once into shell vars/arrays; the hot path is pure-bash lookups + the grep matches regex routing inherently needs.
- Behavior identical: module suite **46/0**, `compass-route --eval` **96.9%**.
- Suite wall-clock **~112s → ~14s**; single route ~0.05s.

## docs: world-class Mermaid diagrams
- **router/README:** a **hero** cascade diagram (heuristic → classifier → LLM, color-coded free vs paid), the **7-stage pipeline**, and the **data-flywheel** loop.
- **main README:** the cascade diagram + a reusable-module note in the cost section.

## Verification
shellcheck clean · doctor ok · parity 96.9% · Mermaid fences balanced. `validate` is the gate; SDLC bot checks need `ANTHROPIC_API_KEY` (infra, non-gating).