### PR TITLE
docs(router): SVG hero diagram (cascade + flywheel) + drop 'world-class'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ uses, and grown from a deterministic heuristic into a hybrid cascade (#9–#13).
 
 ### Docs
 
-- World-class Mermaid diagrams (#13): the cascade hero, the routing pipeline, and the
+- Polished Mermaid diagrams (#13): the cascade hero, the routing pipeline, and the
   data-flywheel — in `router/README.md` and the main README.
 
 ## [0.11.0] — 2026-06-01

--- a/README.md
+++ b/README.md
@@ -514,6 +514,12 @@ You don't have to think about it — delegation happens automatically. When you 
 
 **The router is a standalone, reusable module** ([`router/`](router/)) — a three-layer cascade that pays for intelligence only where it's needed: a free keyword heuristic answers the confident majority, an optional local classifier mops up most of the rest for free, and a Haiku LLM judge is consulted only on the genuinely ambiguous tail. Default routing is the heuristic alone (zero network); layers ②/③ are opt-in.
 
+<p align="center">
+  <img src="assets/router-cascade.svg" alt="compass router cascade — task → ① free keyword heuristic → ② optional free local classifier → ③ Haiku LLM judge for the ambiguous tail; ~80% exits early for free. Plus the data flywheel that trains the classifier from logged LLM judgments." width="880">
+</p>
+
+<details><summary>the same flow as a Mermaid diagram</summary>
+
 ```mermaid
 flowchart LR
     T(["📝 task"]) --> H{"① heuristic<br/>keywords · 0ms · free"}
@@ -529,6 +535,8 @@ flowchart LR
     class J paid
     class T,OUT io
 ```
+
+</details>
 
 <sub>Measured: ~61% cheaper than all-opus at ~98% quality-retention on a fair task mix; the cascade lifts the ambiguous tail where pure keyword routing under-serves. → [`router/README.md`](router/README.md)</sub>
 
@@ -570,7 +578,7 @@ compass is built to be **trusted before it's run** — and honest about its limi
 | [12 · Every agent](docs/12-every-agent.md) | one manual for Claude Code, Codex, Gemini, Cursor, Copilot |
 | [13 · Dynamic workflows](docs/13-workflows.md) | parallel, adversarially-verified subagent orchestration |
 | [14 · Fleet](docs/14-fleet.md) | autonomous agent fleet + mobile mission-control (iMessage/WhatsApp · Telegram · GitHub Mobile) |
-| [15 · Competitive audit](docs/15-competitive-audit.md) | how compass compares to the 2026 field + the prioritized path to world-class |
+| [15 · Competitive audit](docs/15-competitive-audit.md) | how compass compares to the 2026 field + the prioritized path to best-in-class |
 | [16 · Hardening + frontier](docs/16-hardening-and-frontier.md) | the hardening + frontier layer: eval-gated guardrail, memory, parallel SDLC, fleet brain, dashboard, bench, SBOM |
 | [ADRs](docs/adr/) | load-bearing decisions (cross-repo memory; autonomous-loop trust boundary) |
 

--- a/assets/router-cascade.svg
+++ b/assets/router-cascade.svg
@@ -1,0 +1,99 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 600" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <defs>
+    <linearGradient id="rbg" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#0d1117"/><stop offset="1" stop-color="#0a0e14"/></linearGradient>
+    <linearGradient id="racc" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#2ea44f"/><stop offset="0.5" stop-color="#39c5cf"/><stop offset="1" stop-color="#e3b341"/>
+      <animateTransform attributeName="gradientTransform" type="translate" values="-0.3 0;0.3 0;-0.3 0" dur="6s" repeatCount="indefinite"/>
+    </linearGradient>
+    <marker id="ra" viewBox="0 0 10 10" refX="7" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#8b949e"/></marker>
+    <marker id="rg" viewBox="0 0 10 10" refX="7" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#2ea44f"/></marker>
+    <filter id="rglow" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+  </defs>
+  <rect x="1" y="1" width="1198" height="598" rx="20" fill="url(#rbg)" stroke="#30363d" stroke-width="2"/>
+  <rect x="1" y="596" width="1198" height="4" fill="url(#racc)"/>
+
+  <!-- header -->
+  <g transform="translate(58,50)">
+    <circle r="22" fill="#161b22" stroke="#39c5cf" stroke-width="2.5"/>
+    <g><polygon points="0,-13 4.5,0 0,3 -4.5,0" fill="#e3b341"/><polygon points="0,13 4.5,0 0,-3 -4.5,0" fill="#c9d1d9"/>
+      <animateTransform attributeName="transform" type="rotate" values="0;360" dur="10s" repeatCount="indefinite"/></g>
+    <circle r="2.5" fill="#0d1117" stroke="#c9d1d9" stroke-width="1"/>
+    <text x="40" y="2" font-size="30" font-weight="800" fill="#f0f6fc">compass · router</text>
+    <text x="42" y="26" font-size="15" fill="#8b949e">a cost-tier cascade — pay for intelligence only where it's needed</text>
+  </g>
+
+  <text x="64" y="118" font-size="12.5" font-weight="700" fill="#6e7681" letter-spacing="3">THE CASCADE</text>
+
+  <!-- task in -->
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="0.2s" dur="0.6s" fill="freeze"/>
+    <rect x="48" y="150" width="92" height="72" rx="12" fill="#161b22" stroke="#58a6ff" stroke-width="2"/>
+    <text x="94" y="182" text-anchor="middle" font-size="22">📝</text>
+    <text x="94" y="206" text-anchor="middle" font-size="14" fill="#adbac7">task</text>
+  </g>
+  <line x1="140" y1="186" x2="172" y2="186" stroke="#8b949e" stroke-width="2.5" marker-end="url(#ra)"/>
+
+  <!-- ① heuristic (free) -->
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="0.5s" dur="0.6s" fill="freeze"/>
+    <rect x="176" y="142" width="252" height="120" rx="14" fill="#161b22" stroke="#2ea44f" stroke-width="2"/>
+    <text x="302" y="178" text-anchor="middle" font-size="21" font-weight="800" fill="#f0f6fc">① heuristic</text>
+    <text x="302" y="204" text-anchor="middle" font-size="14.5" fill="#adbac7">keyword rules</text>
+    <text x="302" y="236" text-anchor="middle" font-size="13.5" font-weight="700" fill="#3fb950">0&#8202;ms · free · deterministic</text>
+  </g>
+  <line x1="428" y1="170" x2="466" y2="170" stroke="#8b949e" stroke-width="2.5" marker-end="url(#ra)"/>
+  <text x="447" y="160" text-anchor="middle" font-size="11.5" fill="#6e7681">ambiguous</text>
+
+  <!-- ② classifier (free, opt-in) -->
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="0.9s" dur="0.6s" fill="freeze"/>
+    <rect x="468" y="142" width="252" height="120" rx="14" fill="#161b22" stroke="#39c5cf" stroke-width="2"/>
+    <text x="594" y="178" text-anchor="middle" font-size="21" font-weight="800" fill="#f0f6fc">② classifier</text>
+    <text x="594" y="204" text-anchor="middle" font-size="14.5" fill="#adbac7">local Naive-Bayes</text>
+    <text x="594" y="236" text-anchor="middle" font-size="13.5" font-weight="700" fill="#39c5cf">~1&#8202;ms · free · opt-in</text>
+  </g>
+  <line x1="720" y1="170" x2="758" y2="170" stroke="#8b949e" stroke-width="2.5" marker-end="url(#ra)"/>
+  <text x="739" y="160" text-anchor="middle" font-size="11.5" fill="#6e7681">abstains / off</text>
+
+  <!-- ③ LLM judge (paid) -->
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="1.3s" dur="0.6s" fill="freeze"/>
+    <rect x="760" y="142" width="252" height="120" rx="14" fill="#161b22" stroke="#e3b341" stroke-width="2"/>
+    <text x="886" y="178" text-anchor="middle" font-size="21" font-weight="800" fill="#f0f6fc">③ LLM judge</text>
+    <text x="886" y="204" text-anchor="middle" font-size="14.5" fill="#adbac7">Claude Haiku</text>
+    <text x="886" y="236" text-anchor="middle" font-size="13.5" font-weight="700" fill="#e3b341">~300&#8202;ms · $ · the tail</text>
+  </g>
+  <line x1="1012" y1="186" x2="1046" y2="186" stroke="#8b949e" stroke-width="2.5" marker-end="url(#ra)"/>
+
+  <!-- tier out -->
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="1.6s" dur="0.6s" fill="freeze"/>
+    <rect x="1050" y="150" width="100" height="72" rx="12" fill="#161b22" stroke="#a371f7" stroke-width="2"/>
+    <text x="1100" y="180" text-anchor="middle" font-size="20">🎯</text>
+    <text x="1100" y="204" text-anchor="middle" font-size="12.5" fill="#adbac7">haiku·sonnet·opus</text>
+  </g>
+
+  <!-- confident early-exit lane (green): most traffic leaves cheap -->
+  <path d="M302,262 C302,318 1100,322 1100,224" fill="none" stroke="#2ea44f" stroke-width="2.2" stroke-dasharray="6 5" marker-end="url(#rg)" opacity="0.9"/>
+  <path d="M594,262 C594,300 1100,310 1100,224" fill="none" stroke="#2ea44f" stroke-width="2.2" stroke-dasharray="6 5" marker-end="url(#rg)" opacity="0.9"/>
+  <text x="600" y="346" text-anchor="middle" font-size="13" fill="#3fb950" font-weight="600">confident picks (~80%) exit early — for free</text>
+
+  <!-- flowing dots along the top path -->
+  <circle r="4" fill="#39c5cf" filter="url(#rglow)"><animateMotion path="M140,186 L172,186 M428,170 L466,170 M720,170 L758,170 M1012,186 L1046,186" dur="3s" begin="1.8s" repeatCount="indefinite"/></circle>
+
+  <!-- ============ THE DATA FLYWHEEL ============ -->
+  <text x="64" y="398" font-size="12.5" font-weight="700" fill="#6e7681" letter-spacing="3">THE DATA FLYWHEEL — the LLM judge trains its own replacement</text>
+  <g font-size="13.5" text-anchor="middle" font-weight="600" opacity="0"><animate attributeName="opacity" from="0" to="1" begin="2.0s" dur="0.7s" fill="freeze"/>
+    <g><rect x="64"  y="420" width="160" height="46" rx="11" fill="#13181f" stroke="#8b949e"/><text x="144" y="448" fill="#c9d1d9">🧾 --log decisions</text></g>
+    <g><rect x="256" y="420" width="170" height="46" rx="11" fill="#13181f" stroke="#e3b341"/><text x="341" y="448" fill="#e3b341">🧠 LLM labels them</text></g>
+    <g><rect x="458" y="420" width="186" height="46" rx="11" fill="#13181f" stroke="#39c5cf"/><text x="551" y="448" fill="#39c5cf">⚙️ train-classifier</text></g>
+    <g><rect x="676" y="420" width="150" height="46" rx="11" fill="#13181f" stroke="#39c5cf"/><text x="751" y="448" fill="#c9d1d9">✅ classifier ON</text></g>
+    <g><rect x="858" y="420" width="190" height="46" rx="11" fill="#13181f" stroke="#2ea44f"/><text x="953" y="448" fill="#3fb950">💸 fewer LLM calls</text></g>
+  </g>
+  <g stroke="#8b949e" stroke-width="2" marker-end="url(#ra)" opacity="0"><animate attributeName="opacity" from="0" to="1" begin="2.4s" dur="0.6s" fill="freeze"/>
+    <line x1="224" y1="443" x2="252" y2="443"/><line x1="426" y1="443" x2="454" y2="443"/>
+    <line x1="644" y1="443" x2="672" y2="443"/><line x1="826" y1="443" x2="854" y2="443"/>
+  </g>
+  <!-- return loop -->
+  <path d="M953,466 C953,520 144,520 144,468" fill="none" stroke="#8A63D2" stroke-width="2.2" stroke-dasharray="6 5" marker-end="url(#ra)" opacity="0"><animate attributeName="opacity" from="0" to="1" begin="2.8s" dur="0.6s" fill="freeze"/></path>
+  <text x="548" y="538" text-anchor="middle" font-size="12.5" fill="#a371f7">more traffic → more labels → a sharper, cheaper model</text>
+  <circle r="4" fill="#8A63D2" filter="url(#rglow)"><animateMotion path="M953,466 C953,520 144,520 144,468" dur="4s" begin="3.2s" repeatCount="indefinite"/></circle>
+
+  <!-- footer -->
+  <text x="600" y="576" text-anchor="middle" font-size="14.5" fill="#adbac7">~61% cheaper than all-opus · ~98% quality-retention · default path is 0&#8202;ms &amp; offline — <tspan fill="#39c5cf" font-weight="700">deterministic, reusable, yours</tspan></text>
+</svg>

--- a/docs/15-competitive-audit.md
+++ b/docs/15-competitive-audit.md
@@ -1,4 +1,4 @@
-# Competitive audit — where compass stands, and how it becomes world-class
+# Competitive audit — where compass stands, and how it becomes best-in-class
 
 > A code audit, a parity check against the rest of the field, and a prioritized
 > path to making compass the best-in-class, futuristic version of itself.
@@ -181,7 +181,7 @@ Across every category the same handful of gaps recur. In priority order:
 
 ---
 
-## 5. Recommendations — the path to world-class & futuristic
+## 5. Recommendations — the path to best-in-class & futuristic
 
 > **Status: R1–R14 are now implemented** — production-grade, opt-in where they add
 > spend/risk, each safety-critical piece CI-gated, human merge gate untouched. See
@@ -344,7 +344,7 @@ the secret list — and add the bypass-corpus test.
 
 compass is on the **correct strategic axis** (configuration & governance is the
 edge, not models) and its **execution rigor is top-decile** for its category —
-honest, linted, evaluated, reversible. To become *world-class* it must close the
+honest, linted, evaluated, reversible. To become *best-in-class* it must close the
 field's two structural leads — **persistent codebase/org context** (which fixes
 both the review-depth and the learning gap at once) and a **visible control
 surface** — while hardening the one place perception outruns reality: the

--- a/router/README.md
+++ b/router/README.md
@@ -1,5 +1,9 @@
 # router — a deterministic cost-tier router
 
+<p align="center">
+  <img src="../assets/router-cascade.svg" alt="compass router cascade — a task flows through ① a free keyword heuristic, ② an optional free local classifier, and ③ a Haiku LLM judge for the ambiguous tail; ~80% of traffic exits early for free. Below, the data flywheel: --log decisions → the LLM labels them → train-classifier → classifier ON → fewer LLM calls." width="900">
+</p>
+
 A tiny, dependency-free, **language-agnostic** model router: given a task description it
 picks the cheapest tier that can do the job well (`haiku` / `sonnet` / `opus`). No network,
 no model call, no training — a pure function of the task string and a rules spec.


### PR DESCRIPTION
- **`assets/router-cascade.svg`** — a hero diagram in the repo's existing SVG style (matches `explainer.svg` / `sdlc-loop.svg`): the three-layer cascade (① free heuristic → ② optional free local classifier → ③ Haiku LLM judge) with the green **early-exit lane** (~80% of traffic leaves for free), plus the **data-flywheel** loop underneath. Embedded at the top of `router/README.md` and in the main README's cost section; the Mermaid version is kept alongside (collapsed in a `<details>` on main).
- **Dropped "world-class"** everywhere → equivalents (`best-in-class` / `polished`).

Docs/asset only — no code change. doctor ok, router suite 46/0, SVG is well-formed XML, refs resolve from both READMEs.