### PR TITLE
Pre-launch hardening: truth, manifests, code fixes, README UX, GTM

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "core",
       "source": "./plugins/core",
-      "description": "9 specialist subagents, /ship /review /tdd /pr /adr /triage /scaffold /cost, guardrail + format-on-edit + notify hooks, bootstrap-agent-config skill, Concise output style, and context7/fetch/git MCP servers.",
+      "description": "10 specialist subagents; 12 commands (/ship /review /tdd /pr /adr /triage /scaffold /cost /onboard /spec /sdlc /team-review); guardrail + format-on-edit + notify hooks; bootstrap-agent-config, harden, and route skills; a Concise output style; and version-pinned context7/fetch/git MCP servers (context7 reaches Upstash; fetch makes outbound HTTP).",
       "homepage": "https://github.com/dshakes/compass/tree/main/plugins/core",
       "repository": "https://github.com/dshakes/compass",
       "author": { "name": "Shekhar Mudarapu", "url": "https://github.com/dshakes" },

--- a/.github/workflows/sdlc-autoapprove.yml
+++ b/.github/workflows/sdlc-autoapprove.yml
@@ -47,11 +47,11 @@ jobs:
           # 1. Author allowlist — never a human's in-progress PR.
           case ",$TRUSTED_AUTHORS," in *",$AUTHOR,"*) : ;; *) deny "author '$AUTHOR' not in the trusted set" ;; esac
 
-          # 2. Green checks only.
+          # 2. Green checks only — deny when rollup is empty or unknown (no required checks = not eligible).
           rollup="$(gh pr view "$PR" --json statusCheckRollup --jq '[.statusCheckRollup[]?.conclusion // .statusCheckRollup[]?.state] | unique | join(",")' 2>/dev/null || echo unknown)"
           case "$rollup" in
-            SUCCESS|success|"SUCCESS,"*|*",SUCCESS") : ;;
-            *) printf '%s' "$rollup" | grep -qiE 'fail|error|pending|cancel' && deny "checks not all green ($rollup)" ;;
+            SUCCESS|success) : ;;
+            *) deny "checks not all green or no required checks present ($rollup)" ;;
           esac
 
           # 3. Diff-scope allowlist + fail-closed destructive globs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Pre-launch hardening (truth + manifests + fixes)
+
+- **Manifests aligned to the release** — `plugins/core` + `core-lsp` `plugin.json` version
+  `0.8.0` → `0.12.1`; marketplace description corrected to 10 subagents / 12 commands / 3
+  skills and now discloses the context7/fetch network reach. `new-repo.sh` team pin no longer
+  hardcodes a stale tag (uses the current release).
+- **Docs made falsifiable-proof** — corrected the guardrail corpus size (85 → **61**, the
+  real `compass bench` number) everywhere incl. the SVG; reframed the SDLC loop from
+  "validated live end-to-end" to "logic statically validated in CI; reproduce live via the
+  smoke-test checklist"; relabeled `loop.gif` as a scripted replay; fixed stale workflow
+  counts and a stale version-pin example; added an iMessage/WhatsApp "self-hosted bridge"
+  caveat and a network-egress note in the README safety section.
+- **README UX** — differentiated the headline (eval-gated safety + cost + provenance, not
+  "senior engineer"); added a "verify → first run" quickstart so install → test → use is one
+  path; added the `test-architect` safety-gate to the crew table (10th agent).
+- **Code SHOULD-FIX** — `compass-sbom` dropped dead syft branch + portable requirements glob;
+  `compass scan --staged/--diff` now errors (exit 2) outside a git repo instead of silently
+  passing; `compass doctor` no longer requires `make`; `release.sh` validates the version
+  string; `setup-mcp` writes MCP config via temp file (no eval-quoting hazard);
+  `compass-dashboard` HTML-escapes PR titles; `sdlc-autoapprove` denies on an empty
+  status-check rollup; `orchestrate.sh` safety-net commit uses `git add -u`.
+- **Launch kit** — rewritten with the correct awesome-claude-code eligibility gates (incl. the
+  ≥5-star requirement), an honest submission packet, and multi-channel GTM.
+
 ## [0.12.1] — 2026-06-01
 
 ### Docs
@@ -141,7 +165,7 @@ Every item is CI-gated; the full local gate is green.
   flags, quoted `$HOME`, `find … -delete`, system dirs, `curl|sh` no-space/`zsh`/`sudo`/
   process-sub/eval, `git push origin +main`, `git -c … push --force`, wider secret-file +
   protected-branch sets. Still footgun-prevention, not a security boundary.
-- **Guardrail bypass corpus** (`scripts/test-protect-paths.sh`, R1) — 85-case must-block /
+- **Guardrail bypass corpus** (`scripts/test-protect-paths.sh`, R1) — 61-case must-block /
   must-allow labeled corpus, gated in CI; found and fixed 3 real bugs while being written.
 - **GitHub Actions audit** (`scripts/check-actions.sh`, R3/R4) — gates mirror-drift
   (`.github/workflows/sdlc-*` vs `sdlc/workflows/` templates), least-privilege `permissions:`,
@@ -474,7 +498,7 @@ Every item is CI-gated; the full local gate is green.
 ### Added
 - **Keyless cloud agents** (`sdlc/selfhosted/`) — review / audit / implement workflows that
   shell out to `claude -p` / `codex exec` on a self-hosted runner (your **subscription** — no
-  API key or token). `setup.sh --self-hosted`. Proven end-to-end on a pilot PR.
+  API key or token). `setup.sh --self-hosted`. Statically validated in CI (actionlint + selftest); a live smoke-test checklist is provided.
 - **One-command onboarding** — `setup.sh --all`: labels + workflows + CODEOWNERS + commit/push
   + secrets + branch protection (via the GitHub API).
 - **Subscription auth for hosted runners** — workflows accept `CLAUDE_CODE_OAUTH_TOKEN`

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # 🧭 compass
 
-### One config that turns Claude Code, Codex, and Gemini into your most senior engineer — by default, in every repo.
+### Eval-gated guardrails, a measured cost router, and signed releases for Claude Code, Codex & Gemini — auditable config you own, not a service.
 
-It reads before it changes, stays in scope, and verifies before it says "done." It blocks the catastrophic, formats every edit, spends the cheap model on cheap work, and can even open and fix its own PRs. You install it once. You always merge.
+One install gives every agent, in every repo: catastrophic actions **blocked before they run** (with a published precision/recall number), secrets caught at the boundary, the cheap model spent on cheap work, supply-chain **provenance you can verify** — and an optional loop that opens and **fixes its own PRs**. No service, no `curl | sh`, `git pull` to update. You always merge.
 
 *Linting made bad code visible. CI made it unmergeable. compass makes a careless agent harmless — by default.*
 
@@ -57,7 +57,7 @@ No app. No service. No `curl | sh`. Just files you can read, audit, and `git pul
 
 <div id="contents"></div>
 
-**Contents** &nbsp;·&nbsp; [Why compass?](#why-compass) &nbsp;·&nbsp; [What you get](#what-you-get) &nbsp;·&nbsp; [Install](#install) &nbsp;·&nbsp; [See it work](#see-it-work) &nbsp;·&nbsp; [Autonomous SDLC](#autonomous-sdlc) &nbsp;·&nbsp; [The fleet](#the-autonomous-fleet) &nbsp;·&nbsp; [How it fits together](#how-it-fits-together) &nbsp;·&nbsp; [The crew](#the-crew-9-subagents-12-commands-3-workflows) &nbsp;·&nbsp; [Guardrails](#guardrails-and-automation) &nbsp;·&nbsp; [The compass CLI](#the-compass-cli) &nbsp;·&nbsp; [Connected & extensible](#connected-and-extensible) &nbsp;·&nbsp; [Cost model](#cost-model) &nbsp;·&nbsp; [Safety & status](#safety-honesty-and-status) &nbsp;·&nbsp; [Docs](#docs)
+**Contents** &nbsp;·&nbsp; [Why compass?](#why-compass) &nbsp;·&nbsp; [What you get](#what-you-get) &nbsp;·&nbsp; [Install](#install) &nbsp;·&nbsp; [See it work](#see-it-work) &nbsp;·&nbsp; [Autonomous SDLC](#autonomous-sdlc) &nbsp;·&nbsp; [The fleet](#the-autonomous-fleet) &nbsp;·&nbsp; [How it fits together](#how-it-fits-together) &nbsp;·&nbsp; [The crew](#the-crew-10-subagents-12-commands-3-workflows) &nbsp;·&nbsp; [Guardrails](#guardrails-and-automation) &nbsp;·&nbsp; [The compass CLI](#the-compass-cli) &nbsp;·&nbsp; [Connected & extensible](#connected-and-extensible) &nbsp;·&nbsp; [Cost model](#cost-model) &nbsp;·&nbsp; [Safety & status](#safety-honesty-and-status) &nbsp;·&nbsp; [Docs](#docs)
 
 ---
 
@@ -79,17 +79,17 @@ The whole point is **less friction and fewer nasty surprises**, in every repo, f
 Everything above is on after a single install. Here's what's in the box, each link jumps to the detail:
 
 - ⭐ **It runs your PRs — and fixes its own review comments.** The headline: an optional [autonomous pipeline](#autonomous-sdlc) reviews, security-checks, tests, and cross-audits every change, then pushes its *own* fixes until it's green. You just merge. (Try it locally in 30 seconds, no tokens.) [→](#autonomous-sdlc)
-- ✅ **A senior crew on call.** 9 cost-tiered specialist subagents, 12 slash-commands, and 3 parallel "dynamic workflows" that review and audit in parallel and fact-check each other. [→](#the-crew-9-subagents-12-commands-3-workflows)
+- ✅ **A senior crew on call.** 10 cost-tiered specialist subagents, 12 slash-commands, and 3 parallel "dynamic workflows" that review and audit in parallel and fact-check each other. [→](#the-crew-9-subagents-12-commands-3-workflows)
 - 🛰️ **A fleet that runs your repos — from your phone.** The second headline: scheduled, governed agents scan, security-fix, and test across *all* your repos, each fix forced through a test gate; watch and approve from **GitHub Mobile, Slack/Telegram, or iMessage/WhatsApp**. You still merge. [→](#the-autonomous-fleet)
 - ✅ **Every agent, one source.** Claude Code, Codex, Gemini — plus Cursor / Windsurf / Copilot via the open [`AGENTS.md`](https://agents.md/) standard — read the *same* playbook. Switch or mix vendors without rewriting a thing. [→](#connected-and-extensible)
 - ✅ **Guardrails that stay out of your way.** 4 hooks block disasters, format edits, and orient the agent — silently. [→](#guardrails-and-automation)
 - ✅ **It onboards you and proves its value.** `compass onboard` gets you productive in a new repo in minutes; `compass impact` shows what it saved. [→](#the-compass-cli)
 - ✅ **Cheaper by design, measurably.** Model routing is now scored against an eval set and gated in CI. [→](#cost-model)
-- ✅ **Trust you can measure.** The guardrail is data-driven and **eval-gated** — `compass bench` reports its precision/recall (100/100 on an 85-case bypass corpus) and the router's accuracy, in CI. [→](docs/16-hardening-and-frontier.md)
+- ✅ **Trust you can measure.** The guardrail is data-driven and **eval-gated** — `compass bench` reports its precision/recall (100/100 on a 61-case bypass corpus) and the router's accuracy, in CI. [→](docs/16-hardening-and-frontier.md)
 - ✅ **It remembers, sees, and improves.** Opt-in persistent **memory** carries learnings across sessions and repos; `compass dashboard` shows impact + spend + live fleet PRs in one panel; the **fleet brain** proposes new rules from recurring findings (you accept them). [→](docs/16-hardening-and-frontier.md)
 
 <p align="center">
-  <img src="assets/hardening-frontier.svg" alt="The hardening + frontier layer: a HARDENED CORE (eval-gated guardrail, 85-case bypass corpus, compass bench at 100% precision/recall, actions audit), a FRONTIER of opt-in capabilities (persistent memory, parallel SDLC, fleet brain, cost-aware router, spec-kit interop, SBOM + signed commits), and a zero-infra CONTROL SURFACE (compass dashboard) — all flowing into an unmoved human merge gate." width="900">
+  <img src="assets/hardening-frontier.svg" alt="The hardening + frontier layer: a HARDENED CORE (eval-gated guardrail, 61-case bypass corpus, compass bench at 100% precision/recall, actions audit), a FRONTIER of opt-in capabilities (persistent memory, parallel SDLC, fleet brain, cost-aware router, spec-kit interop, SBOM + signed commits), and a zero-infra CONTROL SURFACE (compass dashboard) — all flowing into an unmoved human merge gate." width="900">
 </p>
 <p align="center"><sub>The hardening + frontier layer — measurable trust, self-improving config, cheaper & visible, human merge gate unmoved. <a href="docs/16-hardening-and-frontier.md">Full breakdown →</a></sub></p>
 
@@ -117,7 +117,7 @@ compass quickstart                       # previews, asks, then wires it into ~/
 
 ```bash
 git clone https://github.com/dshakes/compass ~/compass && cd ~/compass
-git checkout v0.10.0     # optional: pin to a release instead of tracking main
+git checkout v0.12.1     # optional: pin to a release instead of tracking main
 ./quickstart.sh
 ```
 
@@ -150,6 +150,21 @@ Symlink install means `git pull` (or `brew upgrade`) updates everything; use `./
 
 → **New here?** [Using compass](docs/11-using-compass.md) walks through the pieces in plain language and the daily workflow.
 
+### ✅ Verify it works → your first run
+
+```bash
+compass doctor      # validate the install (JSON, hooks, plugin sync, symlinks) — expect "0 error"
+compass status      # is compass active here, and what's loaded?
+```
+
+Then just open Claude Code as usual — the manual, guardrails, subagents, commands, and live status line are already loaded. Three ways to feel it working in a minute:
+
+1. **Watch a footgun get blocked.** Ask the agent to `rm -rf /` or write a `.env` — the guardrail denies it before it runs (and logs it: `compass audit-log`).
+2. **Run a senior workflow.** Type `/review` to review your current diff, or `/ship` to test → review → commit.
+3. **See cost routing.** `compass route "redesign the auth model"` → `opus`; `compass route "fix a typo"` → `haiku`. `compass impact` shows what it's saved you as you work.
+
+No tokens, no signup for any of the above — that's the whole local experience.
+
 <div align="right"><a href="#contents">↑ top</a></div>
 
 ---
@@ -163,7 +178,7 @@ Symlink install means `git pull` (or `brew upgrade`) updates everything; use `./
 
 A normal session after install — there's nothing extra to invoke:
 
-1. **Open any repo.** The manual, guardrails, 9 subagents, 12 commands, and the live status line are already loaded.
+1. **Open any repo.** The manual, guardrails, 10 subagents, 12 commands, and the live status line are already loaded.
 2. **Ask for a change.** It plans, implements, and hands the test run to a cheap Haiku subagent while Opus stays on the hard parts. Every file it touches is auto-formatted.
 3. **Dangerous command?** `rm -rf $HOME`, a secret write, a force-push to `main` → **blocked before it runs.** `rm -rf ./build` sails straight through.
 4. **`/ship`, then open the PR.** The [autonomous loop](#autonomous-sdlc) reviews, security-checks, tests, and cross-audits — and **fixes its own Blocking findings** on the branch until it's green. You review and merge.
@@ -201,7 +216,7 @@ Opus 4.8 · myrepo · main* · 45k ctx · $1.23 · 🧭 🛡1 🧹2 💡1 📉~$
 <p align="center">
   <img src="assets/loop.gif" alt="The autonomous loop on a real PR: Reviewer flags a bug as Blocking + QA red → the Builder pushes a fix commit → re-review goes CLEAN, QA green → mergeable, awaiting a code-owner approval (you merge)." width="820">
 </p>
-<p align="center"><sub>↑ a real run (PR #4): Reviewer flagged the bug → Builder pushed the fix → re-review went green → you merge. (<a href="sdlc/SMOKETEST.md">reproduce it yourself</a>)</sub></p>
+<p align="center"><sub>↑ a scripted replay of the loop on PR #4: Reviewer flags → Builder pushes a fix → re-review goes green → you merge. Run the smoke-test checklist (<a href="sdlc/SMOKETEST.md">sdlc/SMOKETEST.md</a>) to reproduce the behavior on your own repo.</sub></p>
 
 **Three ways to kick it off — only the merge is ever yours:**
 
@@ -240,7 +255,7 @@ export OPENAI_API_KEY=…            # optional — the Codex cross-audit
 ~/compass/sdlc/setup.sh --all      # labels + workflows + CODEOWNERS + secrets + branch protection
 ```
 
-`setup.sh` prompts for and stores these as repo secrets for you. The loop auto-chains **only** with `SDLC_BOT_TOKEN` (GitHub blocks workflow-to-workflow recursion with the default token); without it, the review and one fix still run. Validated end-to-end on a live repo — see [`sdlc/SMOKETEST.md`](sdlc/SMOKETEST.md). Roster, gates, security posture, and troubleshooting: [`docs/09-sdlc.md`](docs/09-sdlc.md).
+`setup.sh` prompts for and stores these as repo secrets for you. The loop auto-chains **only** with `SDLC_BOT_TOKEN` (GitHub blocks workflow-to-workflow recursion with the default token); without it, the review and one fix still run. Its logic is statically validated in CI (actionlint + selftest); run the smoke-test checklist ([`sdlc/SMOKETEST.md`](sdlc/SMOKETEST.md)) on your repo to verify the live GitHub behavior end-to-end. Roster, gates, security posture, and troubleshooting: [`docs/09-sdlc.md`](docs/09-sdlc.md).
 
 **The same loop, as a text diagram:**
 
@@ -322,7 +337,7 @@ The fleet's control plane is GitHub itself, so you steer it from anywhere — th
 
 - **GitHub Mobile** *(zero setup, universal)* — push when you're needed, view runs/logs, **approve · merge · comment**, trigger any workflow, and `/hold` · `/approve` from a comment.
 - **Any chat app** — `compass notify` pushes digests + "needs you" alerts to **Slack, Discord, Telegram, ntfy, or a webhook** (free, 2-minute setup).
-- **Two-way DM control** — `compass listen` lets you reply `/status` · `/approve #42` · `/build #7` from a local **iMessage/WhatsApp** bridge or **Telegram** (free); it relays to GitHub where the same governed gates apply.
+- **Two-way DM control** — `compass listen` lets you reply `/status` · `/approve #42` · `/build #7` via **Telegram** (built-in, free) or a **self-hosted iMessage/WhatsApp bridge** you run; it relays to GitHub where the same governed gates apply.
 
 ```mermaid
 flowchart LR
@@ -361,7 +376,7 @@ flowchart LR
 
   repo -->|"on PATH"| cli["compass CLI · ~/.local/bin<br/>quickstart · onboard · impact · spend · route"]
 
-  claude --> bundle["manual · guardrail + format hooks<br/>9 subagents (deep tier: Opus 4.8) · commands<br/>status line · MCP (context7/fetch/git)"]
+  claude --> bundle["manual · guardrail + format hooks<br/>10 subagents (deep tier: Opus 4.8) · commands<br/>status line · MCP (context7/fetch/git)"]
   codex --> tiers["tiers: deep / standard / cheap<br/>+ local (Ollama) · router (OpenRouter)"]
 
   claude --> wf["dynamic workflows (parallel + verified)<br/>/compass-review · /compass-audit · /compass-plan"]
@@ -380,19 +395,20 @@ flowchart LR
 
 ---
 
-## The crew: 9 subagents, 12 commands, 3 workflows
+## The crew: 10 subagents, 12 commands, 3 workflows
 
 compass turns one assistant into a **team of specialists**, each scoped to a job and pinned to the right-sized (and right-priced) model.
 
-### 9 specialist subagents, cost-tiered
+### 10 specialist subagents, cost-tiered
 
-A subagent reads dozens of files and runs long searches in its *own* context, then hands back a short conclusion — so your main session stays fast and cheap. compass ships nine, deliberately spread across three model tiers so spend follows difficulty:
+A subagent reads dozens of files and runs long searches in its *own* context, then hands back a short conclusion — so your main session stays fast and cheap. compass ships ten — nine cost-tiered across three model tiers so spend follows difficulty, plus a safety gate:
 
 | Tier | Model | Subagents | For |
 |---|---|---|---|
 | **Deep** | Opus 4.8 | `architect` · `security-auditor` · `debugger` | architecture, security review, subtle bugs |
 | **Standard** | Sonnet 4.6 | `code-reviewer` · `go-engineer` · `rust-engineer` · `docs-writer` · `k8s-operator` | most coding, review, and docs |
 | **Cheap** | Haiku 4.5 | `test-runner` | running tests, parsing failures, log triage |
+| **Gate** | Sonnet 4.6 | `test-architect` | generates + runs unit/e2e tests as the safety gate — no tests, no merge |
 
 ### 12 commands — one-keystroke senior workflows
 
@@ -551,9 +567,10 @@ compass is built to be **trusted before it's run** — and honest about its limi
 - **You own the irreversible.** Agents prepare; humans push, merge, and deploy. Required checks plus a code-owner approval enforce it — there is no "merge to prod" button.
 - **Readable and reversible.** No `curl | sh`. The installer backs up anything it replaces to `~/.claude/backups/`, is idempotent, and `make uninstall` removes only what it added. Pin a tagged release, not `main`.
 - **Guardrails reduce footguns; they are not a security boundary.** Keep least-privilege credentials and review your diffs.
+- **What talks to the network.** compass itself phones home to nothing. The auto-registered MCP servers reach non-Anthropic endpoints — **`context7`** → Upstash (live library docs), **`fetch`** → the URLs you ask it to fetch; **`git`** is local. Everything else (guardrails, router, scanning, CLI) runs locally. Hooks are short, commented shell scripts you can read in `claude/hooks/`; disable any by editing `claude/settings.json` (or skip the plugin entirely).
 - **Grounded, not invented.** Every capability maps to a real, documented Claude Code / Codex primitive — there's a cited mapping (and an honest note on what we *didn't* fabricate) in [`docs/07-practices.md`](docs/07-practices.md). Built on [Anthropic's best practices](https://code.claude.com/docs/en/best-practices), the [agents.md](https://agents.md/) standard, and Garry Tan's [`gstack`](https://github.com/garrytan/gstack).
 
-> **Status: alpha.** The core — manual, hooks, subagents, commands, MCP, plugin — is stable and dogfooded daily. The **SDLC pipeline** is newer: proven end-to-end on a pilot repo, treat it as early. **Dynamic workflows** are a Claude Code research preview (need v2.1.154+). The human merge/deploy gate is permanent, by design.
+> **Status: alpha.** The core — manual, hooks, subagents, commands, MCP, plugin — is stable and dogfooded daily. The **SDLC pipeline** is newer: its logic is statically validated in CI and exercised via a smoke-test checklist you run on your own repo — treat it as early. **Dynamic workflows** are a Claude Code research preview (need v2.1.154+). The human merge/deploy gate is permanent, by design.
 
 <div align="right"><a href="#contents">↑ top</a></div>
 

--- a/assets/hardening-frontier.svg
+++ b/assets/hardening-frontier.svg
@@ -51,7 +51,7 @@
         <text x="145" y="183" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">data-driven guardrail</text>
         <text x="145" y="198" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">sourceable · pure</text></g>
       <g><rect x="246" y="138" width="178" height="74" rx="11" fill="#0d1117" stroke="#3fb950" stroke-width="1.6"/>
-        <text x="335" y="164" text-anchor="middle" font-size="13.5" fill="#e6edf3">85-case corpus</text>
+        <text x="335" y="164" text-anchor="middle" font-size="13.5" fill="#e6edf3">61-case corpus</text>
         <text x="335" y="183" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">must-block / must-allow</text>
         <text x="335" y="198" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">closes every bypass</text></g>
       <g><rect x="436" y="138" width="178" height="74" rx="11" fill="#10231a" stroke="#2ea44f" stroke-width="2.2"/>

--- a/bin/compass
+++ b/bin/compass
@@ -98,7 +98,7 @@ case "$cmd" in
   notify)   run notify "$@" ;;
   listen)   command -v node >/dev/null || { echo "compass listen: node required" >&2; exit 1; }; exec node "$SCRIPTS/compass-listen.mjs" "$@" ;;
   audit-log) run audit-log "$@" ;;
-  doctor)   exec make -C "$ROOT" doctor ;;
+  doctor)   exec "$SCRIPTS/doctor.sh" "$@" ;;
   release)  exec "$SCRIPTS/release.sh" "$@" ;;
   -h|--help|help) usage ;;
   *) echo "compass: unknown command '$cmd'" >&2; echo; usage; exit 2 ;;

--- a/docs/05-plugin.md
+++ b/docs/05-plugin.md
@@ -26,7 +26,7 @@ Local testing from a clone:
 ```
 
 ## What the plugin delivers
-9 subagents · 12 commands · 4 hooks (incl. the `protect-paths` guardrail) ·
+10 subagents · 12 commands · 4 hooks (incl. the `protect-paths` guardrail) ·
 `bootstrap-agent-config` skill · "Concise" output style ·
 3 MCP servers. Validated via `claude plugin details core@compass`
 (≈1,165 always-on tokens; agents/commands cost only when invoked).

--- a/docs/07-practices.md
+++ b/docs/07-practices.md
@@ -26,7 +26,7 @@ and cites them. Read the sources; don't take our word for it.
 | **Lean, committed instructions file with build/test/style/etiquette** (Anthropic, agents.md) | `CLAUDE.md`/`AGENTS.md`; `bootstrap-agent-config` skill; `templates/CLAUDE.md.tmpl` |
 | **`/clear` between tasks; reset after 2 failed corrections** (Anthropic) | `CLAUDE.md` "Context hygiene" |
 | **Self-improving memory — write a rule after each correction** (Anthropic team) | `CLAUDE.md` "Teach me once" (+ native `#`) |
-| **Subagents for file-heavy investigation in a separate context** (Anthropic) | 9 subagents in `claude/agents/` |
+| **Subagents for file-heavy investigation in a separate context** (Anthropic) | 10 subagents in `claude/agents/` |
 | **Writer/Reviewer with fresh context** (Anthropic) | `/ship` (writer) → `code-reviewer`/`security-auditor` (reviewer) |
 | **Deterministic hooks for must-happen-every-time actions** (Anthropic, awesome-claude-code) | `claude/hooks/` (protect-paths, format-on-edit, …) |
 | **Headless `claude -p` for CI / pre-commit / fan-out** (Anthropic) | documented below |

--- a/docs/10-roadmap.md
+++ b/docs/10-roadmap.md
@@ -221,7 +221,7 @@ The through-line: **the PR (and its required checks + human gate) stays the coor
 medium and the safety boundary.** Everything above either *feeds* that loop (scheduled
 agents open PRs; routing trims who reviews) or *enriches* it (teams/memory/checkpoints) —
 none of it removes the human from merge or deploy. We ship one item at a time, behind a flag,
-each validated like the closed loop was (live smoke test in [`sdlc/SMOKETEST.md`](../sdlc/SMOKETEST.md)).
+each validated like the closed loop (CI: actionlint + selftest; live smoke test is a checklist you run in [`sdlc/SMOKETEST.md`](../sdlc/SMOKETEST.md)).
 
 > Want one built? **Work-type routing (#1)** is the shippable next step; **`babysit-prs`
 > (#2)** is the most striking "it runs itself" demo. Cross-repo memory (#6) needs an ADR first.

--- a/docs/15-competitive-audit.md
+++ b/docs/15-competitive-audit.md
@@ -18,7 +18,7 @@ once:
 
 | Layer | What compass ships | The category it competes in |
 |---|---|---|
-| **Config / constitution** | `CLAUDE.md` ≙ `AGENTS.md`, 9 subagents, 12 commands, 4+3 hooks, MCP manifest | SuperClaude, gstack, spec-kit "constitution", awesome-claude-code configs |
+| **Config / constitution** | `CLAUDE.md` ≙ `AGENTS.md`, 10 subagents, 12 commands, 4+3 hooks, MCP manifest | SuperClaude, gstack, spec-kit "constitution", awesome-claude-code configs |
 | **Local orchestration** | `orchestrate.sh` pipeline, 3 dynamic workflows, `compass route` | BMAD-METHOD, claude-flow, Conductor/Vibe-Kanban |
 | **Autonomous SDLC (cloud)** | self-fixing PR loop in GitHub Actions, Reviewer⇄Builder converge | Devin, Factory Droids, Cursor background agents, Codex cloud, GitHub Copilot coding agent |
 | **Fleet + review** | scheduled cross-repo agents, mission-digest, cross-model audit, mobile control | Greptile/CodeRabbit/Qodo (review), Charlie, Sweep |

--- a/docs/16-hardening-and-frontier.md
+++ b/docs/16-hardening-and-frontier.md
@@ -11,7 +11,7 @@ changes the product's spine — readable config, reversible install, you always 
 > are opt-in and labeled experimental in the same honest spirit as the rest of the repo.
 
 <p align="center">
-  <img src="../assets/hardening-frontier.svg" alt="The hardening + frontier layer in three bands flowing to an unmoved human merge gate. HARDENED CORE (stable, CI-gated): policy.sh data-driven guardrail · 85-case bypass corpus · compass bench (100% precision/recall, router 96.9%) · actions audit (drift, least-privilege, SHA-pinning, injection). FRONTIER (opt-in): persistent memory · parallel SDLC + test-impact + diff-size routing · fleet brain (recurring findings to proposed rules) · cost-aware router · spec-kit interop · SBOM + signed commits. CONTROL SURFACE: compass dashboard (impact, spend, live fleet PRs) · --html/--json. Everything flows to the HUMAN MERGE GATE — unmoved by design; you always merge and deploy." width="900">
+  <img src="../assets/hardening-frontier.svg" alt="The hardening + frontier layer in three bands flowing to an unmoved human merge gate. HARDENED CORE (stable, CI-gated): policy.sh data-driven guardrail · 61-case bypass corpus · compass bench (100% precision/recall, router 96.9%) · actions audit (drift, least-privilege, SHA-pinning, injection). FRONTIER (opt-in): persistent memory · parallel SDLC + test-impact + diff-size routing · fleet brain (recurring findings to proposed rules) · cost-aware router · spec-kit interop · SBOM + signed commits. CONTROL SURFACE: compass dashboard (impact, spend, live fleet PRs) · --html/--json. Everything flows to the HUMAN MERGE GATE — unmoved by design; you always merge and deploy." width="900">
 </p>
 
 <p align="center"><sub>↑ the hardening + frontier layer. Below, the same layer as a text diagram:</sub></p>
@@ -20,7 +20,7 @@ changes the product's spine — readable config, reversible install, you always 
 flowchart TB
   subgraph HARDEN["🛡️ Hardened core — stable, CI-gated"]
     pol["policy.sh<br/>data-driven guardrail<br/>(sourceable, pure)"]
-    corp["85-case bypass corpus<br/>+ benchmark<br/>100% precision / recall"]
+    corp["61-case bypass corpus<br/>+ benchmark<br/>100% precision / recall"]
     act["check-actions.sh<br/>drift · least-priv · pinning · injection"]
     pol --> corp
   end
@@ -65,7 +65,7 @@ contract. Every bypass the audit found is closed:
 | `git push origin +main` (plus-refspec), `git -c k=v push --force` | blocked |
 
 This is **"policy-as-code with an eval"**: [`scripts/test-protect-paths.sh`](../scripts/test-protect-paths.sh)
-is an 85-case labeled corpus (must-block / must-allow) — the highest-stakes file finally
+is a 61-case labeled corpus (must-block / must-allow) — the highest-stakes file finally
 has a test, and it found 3 real bugs while being written. Still footgun-prevention, **not
 a security boundary** — unchanged framing.
 

--- a/docs/alpha.md
+++ b/docs/alpha.md
@@ -34,7 +34,7 @@ pushes → re-review → repeat until clean (you still merge)?
 ```bash
 cd <any-repo>          # needs the Claude GitHub App installed
 export CLAUDE_CODE_OAUTH_TOKEN=…  OPENAI_API_KEY=…  SDLC_BOT_TOKEN=…
-~/compass/sdlc/setup.sh --all     # installs 10 workflows + the merge gate
+~/compass/sdlc/setup.sh --all     # installs the SDLC workflows + the merge gate
 ```
 The loop auto-chains only with `SDLC_BOT_TOKEN` (a fine-grained PAT). Full walkthrough,
 the why, and troubleshooting: [`09-sdlc.md`](09-sdlc.md). **Newest piece — treat as early.**
@@ -44,7 +44,7 @@ the why, and troubleshooting: [`09-sdlc.md`](09-sdlc.md). **Newest piece — tre
 - **Cloud PR automation** (the closed review⇄fix loop) needs the GitHub App + a
   `SDLC_BOT_TOKEN` PAT, or a self-hosted runner for the keyless path — see
   [`09-sdlc.md`](09-sdlc.md). The local pipeline above needs neither.
-- **Pin a release** (e.g. `v0.9.0`), not `main`, for stability.
+- **Pin a release** (e.g. `v0.12.1`), not `main`, for stability.
 - It's safe to uninstall: `make uninstall` removes only what it added (backups in `~/.claude/backups/`).
 
 ## Please report

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -1,174 +1,238 @@
 # Launch kit (internal) — submit & announce compass
 
-Everything needed to list compass on **awesome-claude-code** and announce it. Prepared
-ahead of time; **you** do the submitting/posting as a human (see why below).
-
-> **Eligibility gate:** awesome-claude-code requires *"over one week since the first public
-> commit."* compass's first commit was **2026-05-25** → **submit on or after 2026-06-02.**
-> A calendar reminder was created for that date.
+Everything to list compass on the awesome-Claude ecosystem and announce it, written to be
+**true** (a reviewer can run every claim) and **differentiated** (lead where the giants
+don't compete). **You** submit/post as a human — automated/self-promo posting is exactly
+what these communities flag, and awesome-claude-code *bans* non-human submissions.
 
 ---
 
-## 1. List on awesome-claude-code
+## 0. Pre-flight — hard eligibility gates (check ALL before submitting)
 
-**Their rules (do NOT break — they ban for it):** submissions are **Web-UI issue-form only**.
-**Do not open a PR. Do not use the `gh` CLI. Must be submitted by a human.** (So there is no
-"raise a PR" here — the one-click action is the pre-filled issue form; the maintainer's bot
-turns an approved issue into the PR automatically.)
+awesome-claude-code rejects (and cooldown-bans) on these. Verify each at submission time:
 
-### ✅ One-click action (open on/after 2026-06-02)
-Opens the issue form with the dropdowns + short fields pre-filled:
+| Gate | Requirement | Status |
+|---|---|---|
+| **Repo public age** | ≥ 7 days since first commit | ✅ first commit 2026-05-24 → met on/after 2026-05-31 |
+| **Stars** | **≥ 5 stars** | ⚠️ **GATE — get to ≥ 5 before submitting** (share with a few colleagues first) |
+| **Account age** | GitHub account ≥ 14 days | ✅ (existing account) |
+| **No other open issues** by you in their repo | 0 | ✅ confirm at submit time |
+| **Human, web UI** | issue **form** in a browser — **not** `gh`, **not** an agent, **not** a PR | ⚠️ you do this by hand |
+| **Not crypto-related** | n/a | ✅ |
 
-```
-https://github.com/hesreallyhim/awesome-claude-code/issues/new?template=recommend-resource.yml&title=%5BResource%5D+compass+%E2%80%94+config+manager+for+Claude+Code+%2B+Codex&display_name=compass&category=Tooling&subcategory=Tooling%3A+Config+Managers&primary_link=https%3A%2F%2Fgithub.com%2Fdshakes%2Fcompass&author_name=Shekhar+Mudarapu&author_link=https%3A%2F%2Fgithub.com%2Fdshakes&license=MIT
-```
+> The ≥ 5 stars gate is the one thing that will silently fail the submission. Do it first.
 
-If any field didn't pre-fill, set it manually (verbatim — these match their dropdowns exactly):
+---
+
+## 1. Primary listing — awesome-claude-code (the canonical list)
+
+**Submission model (2026):** you do **not** open a PR and do **not** edit files. You open a
+GitHub **issue form** in the browser; a bot validates it; the maintainer's bot turns an
+approved issue into the PR. Read `docs/CONTRIBUTING.md` + `docs/CODE_OF_CONDUCT.md` first
+(the form makes you attest you did).
+
+**Pre-flight rubric:** run their own reviewer prompt on compass before submitting —
+`.claude/commands/evaluate-repository.md` in their repo (scores Code Quality, Security,
+Docs/Transparency, Functionality, Hygiene). compass should score well; fix anything it flags.
+
+### Open the form (in a browser, logged in, on/after the star gate is met)
+`https://github.com/hesreallyhim/awesome-claude-code/issues/new?template=recommend-resource.yml`
+
+### Field values (verbatim)
 
 | Field | Value |
 |---|---|
 | Display Name | `compass` |
-| Category | `Tooling` |
-| Sub-Category | `Tooling: Config Managers` |
+| Category | `Tooling` — sub-category **`Tooling: Config Managers`** *(if the form routes plugins to `Agent Skills` / `General`, accept it; the maintainer recategorizes — don't fight the dropdown)* |
 | Primary Link | `https://github.com/dshakes/compass` |
 | Author Name | `Shekhar Mudarapu` |
 | Author Link | `https://github.com/dshakes` |
 | License | `MIT` |
 
-### Paste into "Description"
-> compass is a **config manager** for Claude Code + Codex: one source of truth, symlinked into `~/.claude` and `~/.codex`, that makes both tools behave consistently in every repo. It ships a lean operating manual (`CLAUDE.md` ≙ `AGENTS.md` via symlink — one source for both tools), guardrail + auto-format hooks, cost-tiered specialist subagents, workflow commands, and an optional **human-gated autonomous PR loop** (label an issue *or* open a PR → review → security → tests → Codex cross-audit → **auto-fixes its own Blocking findings** → re-review → you merge), steerable mid-flight from a PR comment (`/revise`, `/hold`, `/approve`). The loop is **validated end-to-end on a live repo**.
->
-> It's **modular** — the manual + guardrails are the core; everything else is opt-in. A small `compass` CLI adds local tooling: `compass onboard` gets you productive in a new repo in minutes, and `compass impact` shows what it actually saved you (footguns blocked, files auto-formatted, `$` saved by cheap-model tiering). Two more optional notes: the `AGENTS.md` standard means the same manual also feeds Cursor/Windsurf/Copilot (and Gemini CLI via `--gemini`), and the Codex cheap tier can run on a local model or a cost router. Use as little or as much as you want.
->
-> **Install:** `git clone https://github.com/dshakes/compass ~/compass && cd ~/compass && make install && make doctor`. **Uninstall:** `make uninstall` (removes only what it created). Zero-setup alternative inside Claude Code: `/plugin marketplace add dshakes/compass` then `/plugin install core@compass`.
->
-> **Disclosures (per CONTRIBUTING):** Modifies shared files — symlinks config into `~/.claude`, `~/.codex`, and (with `--gemini`) `~/.gemini` (idempotent, backed up, all reversible via `make uninstall`). Network beyond Anthropic only via opt-in tools: context7 + fetch MCP (auto-registered, secret-free), the opt-in cloud SDLC agents (GitHub API, OpenAI for the Codex audit), optional Playwright/Postgres MCP, and an optional Codex cost router (OpenRouter) — none enabled silently (see SECURITY.md egress table). **No telemetry. No `--dangerously-skip-permissions` anywhere.** Hooks run documented shell scripts on tool/session events (guardrails + formatting) and never fail a session. MIT.
+### Description (1–3 sentences, no emojis, descriptive not promotional, third-person)
+> compass is a single-source configuration and safety layer for Claude Code, Codex, and
+> Gemini: one operating manual (CLAUDE.md ≙ AGENTS.md), guardrail hooks that block
+> catastrophic actions and secret writes before they run, a cost-tier model router, and an
+> optional human-gated autonomous PR loop. Its guardrail and router are eval-gated — `compass
+> bench` reports precision/recall and routing accuracy in CI — and releases carry verifiable
+> SLSA provenance. Everything is auditable config files installed locally; there is no service
+> and no `curl | sh`.
 
-### Paste into "Validate Claims" / "Specific Task" / "Specific Prompt"
-> After `make install`, ask Claude to run `rm -rf $HOME` → it is **blocked** before executing, while `rm -rf ./build` is allowed. The autonomous loop is proven, not aspirational: on a live private repo, a buggy PR went review-**Blocking** → the Builder auto-fixed it on the branch → re-review **green** (human merge gate held); a `agent:build`-labeled issue had an agent write the change and open a PR; and a `/revise` comment steered the loop to add a requested test. Repeatable via `sdlc/SMOKETEST.md` + `scripts/smoketest-scaffold.sh`.
+### Validate Claims / Specific Task(s) / Specific Prompt(s) — *mandatory for plugins*
+Lead with the claim a reviewer can confirm in 30 seconds, not the loop.
 
-### See it in action (the maintainer explicitly rewards "show me before I run it")
-- Renders on GitHub straight from the repo: the **animated explainer**, the **self-fixing loop diagram** (`assets/sdlc-loop.svg`), a ~25s **terminal demo** (`demo/preview.gif`), and **`assets/loop.gif` — the loop on the *real* PR #4** (Reviewer flags `Sub` Blocking → Builder pushes fix `737d589` → re-review green → you merge). Real data; regenerate with `vhs demo/loop.tape`.
-- **Optional upgrade — a GitHub-UI screencast (§4):** a ~20s capture of the same loop in the PR's Checks tab. Purely nice-to-have now that `loop.gif` already shows the real run.
+> **Task:** Confirm the guardrail and the eval gate, then (optionally) the loop.
+> **Prompt / steps:**
+> 1. `git clone https://github.com/dshakes/compass ~/compass && cd ~/compass && make install && make doctor` (expect `0 error`).
+> 2. In Claude Code, ask it to run `rm -rf $HOME` or write a `.env` → **blocked before it runs**; `rm -rf ./build` is allowed. (`compass audit-log` shows the block.)
+> 3. `bash scripts/compass-bench.sh` → guardrail **100% precision/recall on a 61-case corpus**, router **96.9%** — reproducible, CI-gated.
+> 4. `compass verify v0.12.1` → confirms the release's keyless SLSA provenance.
+> 5. *(Optional, needs a GitHub repo + token)* the autonomous PR loop's logic is statically validated in CI (actionlint + selftest); reproduce the live behavior with the checklist in `sdlc/SMOKETEST.md`.
 
-### Paste into "Additional Comments"
-> **Unique within "Tooling: Config Managers"** — I checked the 3 current entries: **agnix** *lints* config files, **claude-rules-doctor** finds *dead* `.claude/rules/`, **ClaudeCTX** *switches* between configs. None is what compass is: an *opinionated, single-source* config for **Claude Code + Codex** (`AGENTS.md` ≙ `CLAUDE.md`, one source) that also runs an optional **governed, closed autonomous PR loop** — Claude reviews · **Codex cross-audits** · it **auto-fixes its own Blocking findings** with spec/intent verification · re-reviews until green; a labeled issue can become a PR, it's steerable mid-flight (`/revise`), and it reports its own impact (`compass impact`). Humans always merge (branch protection, not trust). (vs the broader entries: SuperClaude / Everything Claude Code are single-tool pattern frameworks; Auto-Claude / The Agentic Startup are standalone orchestrators, not a config; claude-code-tools does Claude↔Codex *handoff*, not a shared config + loop.)
-> **Focused, not a marketplace:** the core is just the operating manual + guardrail hooks — one `make install` and it works immediately; *everything else* (the loop, the CLI, cross-tool, local models) is opt-in and off until you switch it on.
-> **Security (your #1 concern):** no telemetry; **no `--dangerously-skip-permissions`** anywhere; **no auto-update** — you run `git pull` (no `npx @latest`); a network-egress table is in `SECURITY.md`; `install.sh` and the hooks are short and fully commented for review.
-> Alpha. The loop is validated **live end-to-end** on a real repo (review-Blocking → auto-fix → green; `agent:build` issue → agent PR; `/revise` steered in a test). CI self-validates the config (actionlint/shellcheck/unit tests). Ran your `evaluate-repository.md` rubric ahead of time.
+### Additional Comments (uniqueness + security — the maintainer's two filters)
+> **Differentiated, not a category-of-one.** Within *Config Managers* the 3 entries are a
+> linter (agnix), a dead-rule detector (claude-rules-doctor), and a config-switcher (ClaudeCTX);
+> none is an opinionated single source for **Claude Code + Codex**. compass's real wedge is
+> what the broad config frameworks (SuperClaude, Everything Claude Code) lack: an **eval-gated**
+> safety layer with a published precision/recall number, **cost routing that's measured not
+> asserted**, and **SLSA supply-chain provenance** for the config itself — directly answering
+> the marketplace-plugin-hijack concerns of 2026.
+> **Security (your #1 filter):** no telemetry; **no `--dangerously-skip-permissions`** anywhere;
+> no auto-update (you `git pull`); install is reversible (`make uninstall`). **Network beyond
+> Anthropic only via opt-in MCP:** `context7` → Upstash (library docs), `fetch` → URLs you
+> request; everything else is local. Hooks are short, commented shell scripts in `claude/hooks/`,
+> disabled by editing `claude/settings.json`. Egress table in `SECURITY.md`. MIT.
 
-### The required checklist (tick all — they're true)
-- [x] Not already submitted · [x] **over one week since first commit** (true on/after Jun 2) · [x] links work · [x] no other open issues in their repo · [x] human
+### After acceptance — add the badge to README
+```markdown
+[![Mentioned in Awesome Claude Code](https://awesome.re/mentioned-badge.svg)](https://github.com/hesreallyhim/awesome-claude-code)
+```
 
-**Approval odds (honest, after scanning their live repo May 2026): ~75–85%.** In favor: the *Config Managers* subcategory has only 3 entries (a linter, a dead-rule detector, a config-switcher) and compass is genuinely distinct; security posture is strong (their stated #1 filter — egress table, no telemetry, no dangerous flags, commented scripts); clear install/uninstall, demos, and a *live-validated* loop give evidence; precedent shows broad configs (SuperClaude, claude-code-tools) get listed; format is airtight (human issue-form, 1-week age gate met Jun 2). The one real swing factor: CONTRIBUTING explicitly *"values focused resources… select a small subset"* and is wary of **bloat / complex systems with long onboarding** — compass is comprehensive. Mitigation is baked into the Description/Comments: lead with the single differentiator and "the core is tiny, everything else opt-in." The decision is the maintainer's subjective focused-vs-bloat call.
+---
 
-### Uniqueness check (done — compass is NOT a category-of-one, but it is differentiated)
-The list already has similar resources; the maintainer requires uniqueness, so lead with the real differentiator, not breadth.
+## 2. Secondary listings (lower bar, parallel reach)
 
-**Same subcategory — Tooling: Config Managers (the 3 current entries; this is the comparison the maintainer checks):**
-
-| Existing entry | What it is | How compass differs |
+| Channel | How | Notes |
 |---|---|---|
-| **agnix** | a *linter/validator* for Claude config files (CLAUDE.md/AGENTS.md/SKILL.md/hooks/MCP) | compass *is* the config (a single source), not a linter for one |
-| **claude-rules-doctor** | CLI that finds *dead* `.claude/rules/` (globs that match nothing) | compass ships + governs the rules cross-tool; not a dead-file detector |
-| **ClaudeCTX** | *switches* your entire Claude config with one command | compass is one opinionated source + a governed loop, not a profile-switcher |
+| **claudemarketplaces.com** | Auto-crawls GitHub for a valid `.claude-plugin/marketplace.json` — **already valid** (name, owner, plugins[], pinned versions). Nothing to submit; optionally email `hi@claudemarketplaces.com`. | Discovery-based. |
+| **Chat2AnyLLM/awesome-claude-plugins** | PR-based awesome-list for plugins/marketplaces — add an entry. | Standard PR. |
+| **jeremylongshore/claude-code-plugins-plus-skills** (`ccpi`) | Submit repo link per its CONTRIBUTING / email `jeremy@intentsolutions.io`. | Accepted ones get featured. |
+| **aitmpl.com** | Aggregator; gets picked up once you're in a crawled marketplace. | Passive. |
+| **anthropics/claude-plugins-official** | Highest bar — directory submission form; automated validation + safety screening. | Apply after traction. |
 
-**Broader-config entries (other subcategories), for context:**
-
-| Existing entry | What it is | Overlap | How compass differs |
-|---|---|---|---|
-| **SuperClaude** (General) | config framework: commands, personas, methodologies | "config framework w/ commands" | no cross-tool single source, no autonomous PR loop, no cross-model audit, no governance/ADRs |
-| **Everything Claude Code** (General) | broad grab-bag of exemplary patterns | breadth | compass is *integrated + opinionated + installable* with a governed loop, not a pattern store |
-| **Claude Codex Settings** (General) | cross-tool integration plugins, "not overly-opinionated" | Claude+Codex | compass is *opinionated senior-engineer defaults* + the loop, not integration plugins |
-| **claude-code-tools** (General) | session continuity + Claude↔Codex handoff + safety hooks | cross-agent + hooks | compass shares one *config* across tools + a review/fix loop, not handoff/continuity |
-| **Auto-Claude / The Agentic Startup** (Orchestrators) | autonomous multi-agent SDLC frameworks | "autonomous SDLC" | those are standalone orchestrators; compass is a *config* whose loop is one optional, human-gated layer with a Codex cross-audit |
-
-**The non-arbitrary unique intersection:** an *opinionated, single-source config for both Claude Code and Codex* **+** a *governed, closed PR loop with a cross-model (Claude+Codex) second opinion, spec/intent verification, and a hard human merge gate.* No listed resource combines those. We submit under **Tooling: Config Managers** (only 3 entries — a linter, a rules-checker, a config-switcher — none opinionated configs), which is both accurate and keeps us out of the crowded "General" config-framework bucket where SuperClaude lives.
-
-**Honest risk:** a selective curator could still see "another config framework." Mitigation is baked into the Description/Comments above — lead with the cross-tool + cross-model-loop angle, never with "comprehensive."
+Install path for all of them is already shipped: `/plugin marketplace add dshakes/compass` → `/plugin install core@compass`.
 
 ---
 
-## 2. Launch post (short — X / LinkedIn / Discord)
-> 🧭 **compass** — one config that makes **Claude Code, Codex *and* Gemini** behave like your best engineer in every repo. Guardrail hooks, cost-tiered subagents, a `compass` CLI that shows what it saved you, and a **human-gated autonomous PR loop**: label an issue *or* open a PR → it reviews, security-checks, tests, cross-audits with Codex, and **auto-fixes its own findings** (steer it with `/revise`) → you merge. No magic, no `curl\|sh`; every piece is a documented feature you can read. MIT, alpha. → github.com/dshakes/compass
+## 3. Positioning — the one line everything leads with
+
+> **compass — eval-gated guardrails, a measured cost router, and signed supply-chain for
+> Claude Code, Codex & Gemini. Auditable config you own, not a service.**
+
+Do **not** lead with "turns your agent into a senior engineer" — that's Superpowers' owned
+position (~150k★). Lead with the two things the giants *don't* have: **measured safety** and
+**provenance**. The self-fixing PR loop is the demo; the eval numbers and `compass verify` are
+the proof.
 
 ---
 
-## 3. Credibility pitches for public portals (post as a human, from your accounts)
+## 4. Go-to-market — channels (executive tone, honest, you post as a human)
 
-> **Why you, not me:** I have no auth to these platforms, and — more importantly —
-> automated/self-promo posting is exactly what these communities flag as spam (it would *hurt*
-> credibility, the opposite of the goal). These are ready to post; engage genuinely and stay to
-> answer comments (that's what earns trust). Check each community's self-promo rules first.
+> Post from your own accounts, engage genuinely, stay to answer. Check each community's
+> self-promo rules. Sequence: GitHub stars → awesome-claude-code → Show HN (Tue–Thu AM PT) →
+> X/LinkedIn same day → Reddit → dev.to write-up.
 
 ### Show HN
-**Title:** `Show HN: Compass – one config so Claude Code, Codex, and Gemini act like your best engineer`
+**Title:** `Show HN: Compass – eval-gated guardrails + cost router + signed releases for Claude Code`
 **Body:**
-> I kept rebuilding the same Claude Code / Codex / Gemini setup in every repo, so I shipped it once. Compass is a config manager: it symlinks one source into ~/.claude and ~/.codex (and ~/.gemini) so the tools share a lean operating manual (AGENTS.md is a symlink to CLAUDE.md), guardrail hooks (blocks rm -rf /, secret writes, force-push to main; auto-formats edits), cost-tiered subagents (cheap models for grunt work, Opus for hard calls), and an optional, human-gated autonomous PR loop: label an issue or open a PR and it reviews, security-checks, tests, cross-audits with Codex, then auto-fixes its own Blocking findings and re-reviews until green — steerable mid-flight with /revise, and you still click merge.
-> There's also a compass CLI that onboards you into a new repo and shows what it saved you (footguns blocked, $ saved). It's deliberately "no magic": every piece is a documented feature, no curl|sh, MIT, and CI validates its own config (the loop is validated live end-to-end). Alpha — I'd love feedback, especially on the loop's guardrails. Repo: https://github.com/dshakes/compass
+> I kept rebuilding the same Claude Code / Codex / Gemini setup in every repo, and I didn't
+> trust the "vibes-based" safety in most agent configs — so I built one that's measured.
+> Compass installs one operating manual across ~/.claude and ~/.codex, plus guardrail hooks
+> that block the catastrophic before it runs (rm -rf /, secret writes, force-push to main) and
+> a cost-tier router that sends cheap work to cheap models. Two things I haven't seen elsewhere:
+> (1) the guardrail and router are **eval-gated** — `compass bench` reports 100% precision/recall
+> on a 61-case bypass corpus and 96.9% routing accuracy, in CI, so the safety claim is a number
+> you can reproduce, not a promise; (2) releases carry **SLSA provenance** (`compass verify`),
+> because 2026 had real marketplace-plugin-hijack incidents. There's also an optional, human-gated
+> autonomous PR loop (review → security → tests → Codex cross-audit → auto-fix its own Blocking
+> findings → re-review until green; you merge). It's deliberately no-magic: no service, no
+> curl|sh, MIT, every hook is a commented shell script. Alpha — feedback welcome, especially on
+> the guardrail corpus. https://github.com/dshakes/compass
 
-### r/ClaudeAI (or r/ChatGPTCoding)
-**Title:** `I open-sourced my Claude Code + Codex config — guardrails, cost-tiering, and an autonomous PR loop (MIT)`
-**Body:** (same gist as Show HN, a touch more casual) — lead with the problem (rebuilding config per repo), the 3–4 concrete things you get, the honesty angle (read every file, no curl|sh), MIT + alpha, ask for feedback. Include the hero image.
+### LinkedIn (executive)
+> Most "AI coding agent" setups ask you to trust their safety on faith. I open-sourced **compass**
+> to make it measurable instead.
+>
+> compass is a single-source configuration and safety layer for Claude Code, Codex, and Gemini.
+> What makes it different from the dozens of agent-config repos:
+> • **Safety with a number.** The guardrail that blocks destructive commands and secret writes is
+>   eval-gated — 100% precision/recall on a published 61-case corpus, enforced in CI. You can
+>   reproduce it.
+> • **Cost discipline that's measured.** A cost-tier router (eval-scored, ~61% cheaper than
+>   all-Opus at ~98% quality on a fair task mix) instead of "up to 80%" marketing.
+> • **Supply-chain provenance.** Releases are signed (SLSA); `compass verify` rejects a tampered
+>   download — a direct answer to 2026's marketplace-plugin-hijack incidents.
+> • **No service.** Auditable config files, `git pull` to update, MIT.
+>
+> Plus an optional human-gated loop that reviews and fixes its own PRs — you always merge.
+> Alpha, and I'd value your feedback. → github.com/dshakes/compass
+
+### LinkedIn (authentic / personal — written by hand, first person)
+> I almost didn't post this.
+>
+> A few weeks ago I noticed I was doing the same thing in every repo: re-explaining to Claude
+> Code (and Codex, and Gemini) how I actually work — what to read first, what never to touch,
+> which model to use for which job. Copy-paste config, every time. So I started keeping it in one
+> place. Then it grew teeth.
+>
+> The part that changed my mind about sharing it: I stopped trusting "safe by default" claims —
+> including my own. It's easy to say "it blocks dangerous commands." So I made it prove it. There's
+> a little corpus of 61 commands that must-block or must-allow, and the guardrail is scored against
+> it in CI — 100% precision and recall, and you can run the exact command and see the number. Same
+> for cost: instead of "saves you money," it's an eval you can reproduce.
+>
+> It's called compass. It's alpha. It's MIT. It is honestly not perfect — the autonomous PR loop
+> is the newest part and I've been deliberately careful not to oversell it (its logic is tested in
+> CI; the live behavior you reproduce with a checklist). I'd rather undersell and have you find it
+> better than the README, than the other way around.
+>
+> If you use Claude Code or Codex daily, I'd genuinely love your eyes on the guardrail corpus — tell
+> me what it should catch that it doesn't. That feedback is worth more to me than stars.
+>
+> github.com/dshakes/compass — and thanks to everyone who let me think out loud about this.
 
 ### X / Twitter (thread)
-1. I shipped **compass** 🧭 — one config that makes **Claude Code, Codex, and Gemini** behave like a senior engineer in every repo. MIT, open source. 🧵
-2. It's a config manager: one source → ~/.claude + ~/.codex. Lean operating manual, guardrail hooks (blocks rm -rf /, secret writes, force-push to main), auto-format on edit.
-3. Cost-tiered: grunt work → Haiku/Sonnet, Opus for the hard calls, live $ in the status line.
-4. The fun part — a human-gated autonomous PR loop: **label an issue or open a PR** → review → security → tests → **Codex cross-audit** → **auto-fix its own findings** → re-review until green. Steer it mid-flight with `/revise`. You keep the merge.
-5. And it proves it: `compass impact` shows footguns blocked + `$` saved. No magic, no curl|sh — every piece is a documented feature you can read. Alpha; feedback welcome 👉 github.com/dshakes/compass
+1. Most Claude Code / agent configs ask you to *trust* their safety. I shipped **compass** 🧭 to make it **measurable**. One config for Claude Code, Codex & Gemini. MIT. 🧵
+2. Guardrails with a number: `compass bench` → **100% precision/recall on a 61-case bypass corpus**, in CI. It blocks `rm -rf /`, secret writes, force-push to `main` — and you can reproduce the score, not just read a promise.
+3. Cost routing that's *measured*: an eval-scored cost-tier router, **~61% cheaper than all-Opus at ~98% quality** on a fair task mix. Cheap work → Haiku/Sonnet; hard calls → Opus.
+4. Supply-chain provenance for a config: releases are **SLSA-signed**; `compass verify` rejects a tampered tarball. (2026 had real marketplace-plugin-hijack incidents — this is the answer.)
+5. The demo: an optional human-gated PR loop — review → security → tests → **Codex cross-audit** → **auto-fix its own findings** → green. You keep the merge. No service, no curl|sh. Alpha; feedback welcome 👉 github.com/dshakes/compass
 
-### dev.to / blog (optional, highest-credibility)
-A 600–900 word post: *"One config for Claude Code and Codex — and an autonomous PR loop that fixes its own review findings."* Outline: the per-repo-config problem → what compass ships → the closed loop (with the spec-driven story from SMOKETEST as the hook) → the honesty/security stance → install + uninstall. Link from the README once published.
+### r/ClaudeAI / r/ChatGPTCoding
+**Title:** `I open-sourced an eval-gated safety + cost layer for Claude Code, Codex & Gemini (MIT)`
+**Body:** Same substance as Show HN, slightly more casual. Lead with the problem (per-repo
+config + unmeasured safety), the three proof points (bench number, measured router, provenance),
+then the optional loop, then MIT/alpha + ask for feedback on the corpus. Include the hero image.
 
----
-
-## 4. Record the autonomous loop (the hero asset)
-
-The most impressive, authentic visual is the **real loop on a PR** — review flags a Blocking
-issue, the Builder pushes a fix, checks go green. You capture it (I can't screen-record); I've
-made it turnkey.
-
-### Step 1 — stage a clean BLOCKING → fix → green PR (one paste)
-Run right before recording, on the smoke-test repo (workflows + `SDLC_BOT_TOKEN` already set):
-```bash
-cd ~/workspace/compass-sdlc-smoketest && git checkout -q main && git pull -q
-git checkout -q -b demo/loop-$(date +%s)
-mkdir -p specs
-cat > specs/divide.md <<'EOF'
-# Spec: Divide
-## Acceptance criteria
-1. Divide(10,2) == 5
-2. Returns 0 when the divisor is 0 (no panic)
-3. A table-driven test TestDivide covers both
-EOF
-printf 'package smoketest\n\n// Divide returns a / b.\nfunc Divide(a, b int) int { return a / b }\n' > divide.go
-git add -A && git commit -q -m "feat: add Divide (per specs/divide.md)"
-git push -q -u origin HEAD
-gh pr create --fill --body "Implements specs/divide.md. Spec: specs/divide.md"
-```
-The code is "fine" but violates the spec (no zero-guard, no test) → the reviewer flags it
-**Blocking**, the Builder fixes it on the branch, re-review goes **green**.
-
-### Step 2 — record
-- Open the PR; show the **Checks** + the conversation/commits. Start a screen recording
-  (macOS ⌘⇧5, or Kap/CleanShot for direct GIF).
-- The loop takes a few minutes, so **record the three beats and speed up later**:
-  1. checks running → `review` **red** + `agent:needs-fix`
-  2. the **Builder's fix commit** lands on the branch
-  3. re-review → **green ✓** (mergeable, pending your approval)
-
-### Step 3 — convert + hand back
-```bash
-ffmpeg -i loop.mov -vf "setpts=0.2*PTS,fps=12,scale=1000:-1:flags=lanczos" -loop 0 assets/loop.gif
-```
-(`setpts=0.2*PTS` = 5× speed → ~20–30s.) Then drop `assets/loop.gif` in the repo and ping me —
-I'll wire it under the hero. *(MP4 alternative: upload to a GitHub Release/Issue; GitHub renders
-uploaded `.mp4` as a player — paste that URL instead.)*
-
-> Until it exists, the hero is the animated `assets/explainer.svg` (YC-style, minimal-text) +
-> the terminal demo. The recording becomes the centerpiece once captured.
+### dev.to / blog (highest-credibility, optional)
+600–900 words: *"Stop trusting your AI agent's safety on faith — measure it."* Outline: the
+unmeasured-safety problem → the 61-case corpus + how precision/recall is computed → the measured
+router (cost-at-iso-quality) → provenance (`compass verify`) → the optional loop → install/uninstall.
+Link from README once live.
 
 ---
 
-*Generated as a launch checklist. Update the eligibility date if the first-commit date changes.*
+## 5. Differentiator cheat-sheet (when someone compares you in a thread)
+
+| If they mention… | Lead with |
+|---|---|
+| **Superpowers** ("senior engineer" skills) | "Different aim — compass is the *measured safety + cost + provenance* layer; it composes with skill frameworks, doesn't replace them." |
+| **spec-kit** | "compass has `/spec` and reads spec-kit's `spec.md`; it's a layer on top, not a competitor." |
+| **claude-router / cost tools** | "Ours is eval-scored + CI-gated with a reproducible cost-at-iso-quality number, and it's a reusable module (`router/`)." |
+| **rulebricks / cloud guardrails** | "No service or cloud dependency — auditable files, `git pull` to update; the policy is a corpus-tested pure function." |
+| **amtiYo/agents, agent-kit (config sync)** | "Those sync config; compass *is* opinionated config plus guardrails, routing, provenance, and a governed loop." |
+
+---
+
+## 6. Assets
+
+Render on GitHub straight from the repo: the animated **explainer** (`assets/explainer.svg`),
+the **router cascade** hero (`assets/router-cascade.svg`), the **self-fixing loop diagram**
+(`assets/sdlc-loop.svg`), the **hardening/frontier** map, and a terminal demo
+(`demo/preview.gif`). `assets/loop.gif` is a **scripted replay** of the loop's behavior on PR #4
+(label it as such — it is a VHS reenactment, not a screen recording). The highest-value asset to
+add is a real screen capture of the loop in a PR's Checks tab — turnkey steps below.
+
+<details><summary>Record the real loop (turnkey)</summary>
+
+1. Stage a clean BLOCKING→fix→green PR on the smoke-test repo (workflows + `SDLC_BOT_TOKEN` set):
+   write code that violates a `specs/*.md` acceptance criterion, push, `gh pr create --fill`.
+2. Record the three beats (⌘⇧5 / Kap): checks → `review` red + `agent:needs-fix`; the Builder's
+   fix commit lands; re-review green ✓ (pending your merge).
+3. `ffmpeg -i loop.mov -vf "setpts=0.2*PTS,fps=12,scale=1000:-1:flags=lanczos" -loop 0 assets/loop.gif`
+   (5× speed → ~20–30s). Replace the scripted `loop.gif` and relabel it a real recording.
+</details>
+
+---
+
+*Internal checklist. Re-verify the star count and eligibility gates immediately before submitting.*

--- a/plugins/core-lsp/.claude-plugin/plugin.json
+++ b/plugins/core-lsp/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "core-lsp",
   "displayName": "Core — LSP",
-  "version": "0.8.0",
+  "version": "0.12.1",
   "description": "Language-server intelligence (diagnostics, navigation) for Go, Rust, TypeScript, and Python. Opt-in companion to core — requires the language servers installed on PATH.",
   "author": {
     "name": "Shekhar Mudarapu",

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "core",
   "displayName": "Core",
-  "version": "0.8.0",
+  "version": "0.12.1",
   "description": "Cost-tiered specialist subagents, workflow commands, guardrail + auto-quality hooks, a repo-bootstrap skill, a terse output style, and parity MCP servers — for serious polyglot software work.",
   "author": {
     "name": "Shekhar Mudarapu",

--- a/scripts/check-actions.sh
+++ b/scripts/check-actions.sh
@@ -19,6 +19,7 @@
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+trap 'rm -f /tmp/_inj.$$' EXIT
 pass=0; fail=0
 ok() { printf '  \033[32mok\033[0m   %s\n' "$1"; pass=$((pass + 1)); }
 no() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; fail=$((fail + 1)); }

--- a/scripts/compass-dashboard.sh
+++ b/scripts/compass-dashboard.sh
@@ -83,7 +83,11 @@ if [ "$HTML" = 1 ]; then
     echo "<pre>$("$ROOT/scripts/compass-impact.sh" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g')</pre>"
     if [ -n "$FLEET_TSV" ]; then
       echo "<h2>fleet — open SDLC PRs</h2><table><tr><th>repo</th><th>#</th><th>state</th><th>title</th></tr>"
-      printf '%s\n' "$FLEET_TSV" | awk -F'\t' 'NF>=4{printf "<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>\n",$1,$2,$3,$4}'
+      printf '%s\n' "$FLEET_TSV" | awk -F'\t' '
+        function he(s,  r) {
+          r=s; gsub(/&/,"\\&amp;",r); gsub(/</,"\\&lt;",r); gsub(/>/,"\\&gt;",r); gsub(/"/,"\\&quot;",r); return r
+        }
+        NF>=4{printf "<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>\n",he($1),he($2),he($3),he($4)}'
       echo "</table>"
     fi
   } > "$out"

--- a/scripts/compass-sbom.sh
+++ b/scripts/compass-sbom.sh
@@ -3,11 +3,11 @@
 #
 # In a world of agent-generated changes, "what's in this build, and is any of it known-
 # vulnerable?" becomes a trust differentiator. This detects the ecosystem, emits a simple
-# dependency SBOM (prefers syft/native CycloneDX when present), and runs the native vuln
-# audit. Best-effort + dependency-light: every tool is optional and it degrades to a plain
-# dependency list. With --gate it exits non-zero when the audit finds vulnerabilities.
+# dependency SBOM and runs the native vuln audit. Best-effort + dependency-light: every
+# tool is optional and it degrades to a plain dependency list. With --gate it exits
+# non-zero when the audit finds vulnerabilities.
 #
-#   compass-sbom.sh                 # SBOM + audit for the current repo
+#   compass-sbom.sh                 # dependency list + audit for the current repo
 #   compass-sbom.sh --no-audit      # SBOM only (offline, fast)
 #   compass-sbom.sh --gate          # non-zero exit if the audit finds vulns (CI/QA use)
 #   compass-sbom.sh --json          # machine-readable summary
@@ -26,11 +26,6 @@ sbom_lines=""
 
 add_deps() { deps=$(( deps + $(printf '%s' "$1" | grep -c . ) )); sbom_lines="$sbom_lines$1
 "; }
-
-# Prefer a real SBOM tool if the operator has one.
-if have syft; then
-  eco="$(syft -o cyclonedx-json . 2>/dev/null >/tmp/_sbom.$$ && echo 'syft' || echo none)"
-fi
 
 if [ -f package.json ]; then
   eco="node"
@@ -53,14 +48,13 @@ elif [ -f Cargo.toml ]; then
   have cargo && add_deps "$(cargo tree --prefix none 2>/dev/null | sort -u | tr ' ' '@')"
   if [ "$NO_AUDIT" = 0 ] && have cargo-audit; then cargo audit -q >/tmp/_ca.$$ 2>&1; audit_ran=1
     vulns="$(grep -c 'RUSTSEC' /tmp/_ca.$$ 2>/dev/null || echo 0)"; audit_note="cargo audit"; rm -f /tmp/_ca.$$; fi
-elif [ -f pyproject.toml ] || ls requirements*.txt >/dev/null 2>&1; then
+elif { [ -f pyproject.toml ] || for _f in requirements*.txt; do [ -f "$_f" ] && break; done; }; then
   eco="python"
   if [ -f requirements.txt ]; then add_deps "$(grep -vE '^\s*(#|$)' requirements.txt 2>/dev/null)"; fi
   if [ "$NO_AUDIT" = 0 ] && have pip-audit; then pip-audit -q >/tmp/_pa.$$ 2>&1; audit_ran=1
     vulns="$(grep -cE 'PYSEC|GHSA' /tmp/_pa.$$ 2>/dev/null || echo 0)"; audit_note="pip-audit"; rm -f /tmp/_pa.$$; fi
 fi
 : "${vulns:=0}"
-[ -f /tmp/_sbom.$$ ] && rm -f /tmp/_sbom.$$
 
 if [ "$JSON" = 1 ]; then
   printf '{"ecosystem":"%s","dependencies":%d,"audit_ran":%s,"audit_tool":"%s","vulnerabilities":%d}\n' \

--- a/scripts/compass-scan.sh
+++ b/scripts/compass-scan.sh
@@ -117,8 +117,15 @@ resolve_files() {
 
 # --- Collect built-in findings -------------------------------------------------
 case "$mode" in
-  staged) findings="$(in_git && git diff --cached --no-color -U0 | emit_added | scan_stream)" ;;
-  diff)   findings="$(in_git && git diff --no-color -U0 | emit_added | scan_stream)" ;;
+  staged|diff)
+    if ! in_git; then
+      echo "compass scan: --${mode} requires a git repository (no .git found)" >&2
+      exit 2
+    fi ;;
+esac
+case "$mode" in
+  staged) findings="$(git diff --cached --no-color -U0 | emit_added | scan_stream)" ;;
+  diff)   findings="$(git diff --no-color -U0 | emit_added | scan_stream)" ;;
   all|paths)
     files="$(resolve_files)"
     if [ -n "$files" ]; then

--- a/scripts/new-repo.sh
+++ b/scripts/new-repo.sh
@@ -41,15 +41,16 @@ if [ "$TEAM" = 1 ]; then
   if [ -e .claude/settings.json ]; then
     echo ".claude/settings.json exists — add the pin manually (see docs/08-defaults.md)"
   else
-    cat > .claude/settings.json <<'JSON'
+    PIN="$(git -C "$REPO_HOME" describe --tags --abbrev=0 2>/dev/null || echo main)"   # pin the team to the current release, not a stale literal
+    cat > .claude/settings.json <<JSON
 {
   "extraKnownMarketplaces": {
-    "compass": { "source": { "source": "github", "repo": "dshakes/compass", "ref": "v0.9.0" } }
+    "compass": { "source": { "source": "github", "repo": "dshakes/compass", "ref": "$PIN" } }
   },
   "enabledPlugins": { "core@compass": true }
 }
 JSON
-    echo "wrote .claude/settings.json (pins core@compass for the team)"
+    echo "wrote .claude/settings.json (pins core@compass @ $PIN for the team)"
   fi
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -27,6 +27,10 @@ if [ -z "$VER" ]; then
 fi
 [ -n "$VER" ] || { echo "could not determine version — pass it, e.g. scripts/release.sh v0.10.0"; exit 2; }
 case "$VER" in v*) ;; *) VER="v$VER" ;; esac
+
+# ── strict semver validation — reject anything not matching vMAJOR.MINOR.PATCH ──
+printf '%s\n' "$VER" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+  || { echo "invalid version format — must match vMAJOR.MINOR.PATCH (e.g. v0.10.0)" >&2; exit 2; }
 NUM="${VER#v}"
 TARBALL="https://github.com/$REPO_SLUG/archive/refs/tags/$VER.tar.gz"
 say "Releasing $VER  (dry-run=$DRY)"

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -18,7 +18,6 @@ MARK_END="# <<< compass mcp <<<"
 DRY=0; [ "${1:-}" = "--dry-run" ] && DRY=1
 
 command -v jq >/dev/null || { echo "jq required for setup-mcp.sh" >&2; exit 1; }
-run() { if [ "$DRY" = 1 ]; then echo "  [dry-run] $*"; else eval "$*"; fi; }
 say() { printf '  %s\n' "$*"; }
 
 # Supply-chain pre-flight: never register an unpinned or tampered manifest.
@@ -43,8 +42,16 @@ for name in $names; do
   if jq -e ".servers[\"$name\"].claude==true" "$MANIFEST" >/dev/null; then
     if claude mcp get "$name" >/dev/null 2>&1; then say "already registered: $name"; continue; fi
     cfg="$(jq -c ".servers[\"$name\"] | {type, command, args, env}" "$MANIFEST")"
-    run "claude mcp add-json '$name' '$cfg' --scope user"
-    [ "$DRY" = 1 ] || say "registered: $name"
+    _tmp="$(mktemp)"
+    printf '%s' "$cfg" >"$_tmp"
+    if [ "$DRY" = 1 ]; then
+      echo "  [dry-run] claude mcp add-json '$name' <cfg> --scope user"
+      rm -f "$_tmp"
+    else
+      claude mcp add-json "$name" "$(cat "$_tmp")" --scope user
+      rm -f "$_tmp"
+      say "registered: $name"
+    fi
   fi
 done
 

--- a/sdlc/SMOKETEST.md
+++ b/sdlc/SMOKETEST.md
@@ -10,7 +10,7 @@ workflow chaining. Run it once per major change to the pipeline.
 - [ ] [Claude GitHub App](https://github.com/apps/claude) installed on it.
 - [ ] Secrets set: `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`), `OPENAI_API_KEY`,
       and **`SDLC_BOT_TOKEN`** (fine-grained PAT: Contents + Pull requests = write).
-- [ ] `~/compass/sdlc/setup.sh --all` run on it (labels, 8 workflows on the default
+- [ ] `~/compass/sdlc/setup.sh --all` run on it (labels, the SDLC workflows on the default
       branch, CODEOWNERS, branch protection with required checks `review` + `qa`).
 - [ ] Confirm: `gh api repos/<owner>/<repo>/branches/<default>/protection` shows
       `required_status_checks.contexts = ["review","qa"]`.

--- a/sdlc/orchestrate.sh
+++ b/sdlc/orchestrate.sh
@@ -125,7 +125,7 @@ Stay on branch $BRANCH. Add tests. Build/test what you touch. Commit your work. 
 # safety net: capture any uncommitted work so the diff/PR is complete
 if ! git diff --quiet || ! git diff --cached --quiet; then
   # shellcheck disable=SC2086  # SIGN_FLAG is intentionally word-split (empty or -S)
-  if git add -A && git commit -q $SIGN_FLAG -m "sdlc(builder): $TASK"; then note "committed builder leftovers"
+  if git add -u && git commit -q $SIGN_FLAG -m "sdlc(builder): $TASK"; then note "committed builder leftovers"
   else note "⚠ could not commit builder leftovers — the review/PR may see a stale tree"; fi
 fi
 
@@ -153,7 +153,7 @@ if [ "${SDLC_CONVERGE:-0}" = 1 ]; then
 Edit the code, add/adjust tests, build/test what you touch, commit. Do not push or merge."
     if ! git diff --quiet || ! git diff --cached --quiet; then
       # shellcheck disable=SC2086  # SIGN_FLAG is intentionally word-split (empty or -S)
-      git add -A && git commit -q $SIGN_FLAG -m "sdlc(converge $r): $TASK"
+      git add -u && git commit -q $SIGN_FLAG -m "sdlc(converge $r): $TASK"
     fi
     claude_step review reviewer.md "$REVIEW_MODEL" plan "$REVIEW_TOOLS" "$REVIEW_PROMPT"
     r=$((r + 1))

--- a/sdlc/workflows/sdlc-autoapprove.yml
+++ b/sdlc/workflows/sdlc-autoapprove.yml
@@ -47,11 +47,11 @@ jobs:
           # 1. Author allowlist — never a human's in-progress PR.
           case ",$TRUSTED_AUTHORS," in *",$AUTHOR,"*) : ;; *) deny "author '$AUTHOR' not in the trusted set" ;; esac
 
-          # 2. Green checks only.
+          # 2. Green checks only — deny when rollup is empty or unknown (no required checks = not eligible).
           rollup="$(gh pr view "$PR" --json statusCheckRollup --jq '[.statusCheckRollup[]?.conclusion // .statusCheckRollup[]?.state] | unique | join(",")' 2>/dev/null || echo unknown)"
           case "$rollup" in
-            SUCCESS|success|"SUCCESS,"*|*",SUCCESS") : ;;
-            *) printf '%s' "$rollup" | grep -qiE 'fail|error|pending|cancel' && deny "checks not all green ($rollup)" ;;
+            SUCCESS|success) : ;;
+            *) deny "checks not all green or no required checks present ($rollup)" ;;
           esac
 
           # 3. Diff-scope allowlist + fail-closed destructive globs.


### PR DESCRIPTION
Deep pre-submission pass ahead of listing compass on awesome-claude-code (audited every line via 5 specialist reviews: 2 code, 1 docs-truth, 1 submission-criteria, 1 competitor).

## Truth (every claim a reviewer can now run)
- Guardrail corpus **85 → 61** everywhere (the real `compass bench` number) incl. the SVG.
- SDLC loop: **"validated live end-to-end" → "logic statically validated in CI; reproduce via `sdlc/SMOKETEST.md`."** `loop.gif` relabeled a scripted replay. Stale workflow counts + version-pin fixed.
- iMessage/WhatsApp **self-hosted-bridge** caveat; README **network-egress** disclosure (context7→Upstash, fetch→URLs).

## Manifests (submission-blocking)
- `plugin.json` core + core-lsp **0.8.0 → 0.12.1**; marketplace counts corrected (10 subagents / 12 commands / 3 skills) + network disclosure; `new-repo.sh` team pin now dynamic.

## Code SHOULD-FIX
- sbom dead `syft` branch removed + portable glob; `scan --staged/--diff` exits 2 outside git; `doctor` no longer needs `make`; `release.sh` validates the version; `setup-mcp` uses a temp file (no eval-quote hazard); dashboard HTML-escapes PR titles; `sdlc-autoapprove` denies on empty status-check rollup; `orchestrate` uses `git add -u`.

## README UX + GTM
- Differentiated headline (**eval-gated safety + cost + provenance**, not "senior engineer" — Superpowers' turf); **verify → first-run quickstart** so install → test → use is one path; `test-architect` added to the crew (10 agents); **launch-kit rewritten** with the correct awesome-claude-code eligibility gates (incl. **≥5 stars**), an honest submission packet, and multi-channel GTM (two LinkedIn variants).

## Verification
Full local gate **18/18** (manifests valid · doctor · shellcheck · guardrail corpus · secret self-scan · MCP audit · CLI tests · listener · workflow shape · actions audit · router eval · bench · router module · SDLC selftest · compass-memory · plugin sync · sbom · no-make doctor). `validate` is the CI gate; SDLC bot checks need `ANTHROPIC_API_KEY` (infra, non-gating).