### PR TITLE
Enable 1-hour prompt-cache TTL for the SDLC pipeline (where reuse pays)

### DIFF
--- a/docs/02-cost-and-models.md
+++ b/docs/02-cost-and-models.md
@@ -51,6 +51,24 @@ rate rather than fight it:
   cheaper to cache and higher-signal. Building on the API directly? The `claude-api`
   skill bakes in `cache_control` so apps cache by default.
 
+### 1-hour cache TTL (extended)
+The default cache lives **5 minutes**; the extended TTL is **1 hour** (GA). 1h costs ~2× on
+the *write* but reads stay at 0.1× — a net win **only when the same large prefix is reused
+across calls more than 5 minutes apart**, which is exactly the SDLC pipeline + converge loop
+(`review → fix → review` can span minutes-to-an-hour). It's **not** a win for one-shots
+(`compass onboard`, the router's tiny LLM fallback) — those would just pay the write premium.
+
+Claude Code exposes this only as an **env var** (`ENABLE_PROMPT_CACHING_1H=1`, v2.1.108+) —
+no CLI flag, no `settings.json` field. compass applies it where it pays:
+- **`sdlc/orchestrate.sh`** exports `ENABLE_PROMPT_CACHING_1H=1` for its `claude -p` steps
+  (opt out with `SDLC_CACHE_1H=0`).
+- **GitHub SDLC loop** (`claude-code-action`): set it as a repo/Actions env var or in the
+  workflow's `env:` if you want the hosted converge loop on the 1h TTL too.
+- **Interactive sessions:** add `export ENABLE_PROMPT_CACHING_1H=1` to your shell rc if your
+  day is long, context-heavy sessions (the common case); skip it for short, bursty ones.
+- It does **not** apply to the raw-API path in `router/fallback-llm.sh` — that prompt is below
+  the 1,024-token cache minimum, so caching is a no-op there regardless of TTL.
+
 ## Bring your own model — local LLMs & cost routers (Codex side)
 The cheapest token is one you don't pay for. Codex talks to **any OpenAI-compatible endpoint**,
 so a tier can run on a **local model** (free, private) or a **cost router**:

--- a/sdlc/orchestrate.sh
+++ b/sdlc/orchestrate.sh
@@ -45,6 +45,14 @@ BUILD_MODEL="${SDLC_BUILD_MODEL:-sonnet}"
 SIGN_FLAG=""
 if [ "${SDLC_SIGN:-0}" = 1 ]; then SIGN_FLAG="-S"; git config commit.gpgsign true 2>/dev/null || true; fi
 
+# 1-hour prompt-cache TTL: this pipeline makes many model calls that reuse the SAME repo
+# context, and the converge loop (review→fix→review) re-reads it across gaps >5min — so the
+# longer cache keeps reads hot (0.1x input price) instead of re-paying full input each round.
+# Net win here despite the 2x cache-write premium, precisely because of the reuse. Claude Code
+# reads this env flag at startup; the child `claude -p` calls inherit it. SDLC_CACHE_1H=0 opts
+# out (back to the default 5min TTL — better for genuine one-shots, not this loop).
+if [ "${SDLC_CACHE_1H:-1}" = 1 ]; then export ENABLE_PROMPT_CACHING_1H=1; fi
+
 # Spec-kit interop (R13): if SDLC_SPEC is unset, auto-discover a spec-kit / spec-driven
 # spec so compass becomes the governance+execution layer UNDER the spec-driven standard
 # (github/spec-kit, BMAD, Kiro) rather than competing with it. First match wins; opt out

--- a/sdlc/selftest.sh
+++ b/sdlc/selftest.sh
@@ -195,6 +195,7 @@ src_has "diff-size haiku threshold default is 25"   'SDLC_HAIKU_DIFF_LINES:-25'
 src_has "tiny diff routes review to haiku"          'REVIEW_MODEL="haiku"'
 src_has "SDLC_LITE note text matches"               'SDLC_LITE — skipping Codex audit + security pass (review + QA + human gate remain).'
 src_has "spec-kit discovery order matches"          '.specify/specs/*/spec.md specs/*/spec.md specs/spec.md spec.md SPEC.md docs/spec.md'
+src_has "1h prompt-cache TTL wired (opt-out)"       'ENABLE_PROMPT_CACHING_1H=1'
 
 echo
 printf 'selftest: %d passed, %d failed\n' "$PASS" "$FAIL"


### PR DESCRIPTION
Applies the extended **1-hour** prompt-cache TTL only where it's a net win.

**Why here:** 1h costs ~2× on cache *write* but reads stay 0.1× — it pays off only when the same large prefix is reused across calls >5 min apart. That's `orchestrate.sh`'s multi-step pipeline + the converge loop (`review→fix→review`). One-shots (`compass onboard`, the router's sub-1024-token LLM fallback) would just pay the write premium, so they're left alone.

**How:** Claude Code exposes this only via the env var `ENABLE_PROMPT_CACHING_1H=1` (no CLI flag / settings field, v2.1.108+). `orchestrate.sh` exports it (child `claude -p` inherits); opt out with `SDLC_CACHE_1H=0`.

**Docs:** `docs/02-cost-and-models.md` gains a "1-hour cache TTL" subsection — the tradeoff, plus how to enable it for the GitHub `claude-code-action` loop and interactive sessions. selftest source-anchors the wiring (50/0).

Gate: shellcheck clean · selftest 50/0 · doctor OK.