### PR TITLE
fix: validate.sh on bash 3.2 (macOS) + bump doc pins to v0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ compass quickstart                       # previews, asks, then wires it into ~/
 
 ```bash
 git clone https://github.com/dshakes/compass ~/compass && cd ~/compass
-git checkout v0.12.1     # optional: pin to a release instead of tracking main
+git checkout v0.13.0     # optional: pin to a release instead of tracking main
 ./quickstart.sh
 ```
 

--- a/docs/alpha.md
+++ b/docs/alpha.md
@@ -44,7 +44,7 @@ the why, and troubleshooting: [`09-sdlc.md`](09-sdlc.md). **Newest piece — tre
 - **Cloud PR automation** (the closed review⇄fix loop) needs the GitHub App + a
   `SDLC_BOT_TOKEN` PAT, or a self-hosted runner for the keyless path — see
   [`09-sdlc.md`](09-sdlc.md). The local pipeline above needs neither.
-- **Pin a release** (e.g. `v0.12.1`), not `main`, for stability.
+- **Pin a release** (e.g. `v0.13.0`), not `main`, for stability.
 - It's safe to uninstall: `make uninstall` removes only what it added (backups in `~/.claude/backups/`).
 
 ## Please report

--- a/router/validate.sh
+++ b/router/validate.sh
@@ -37,9 +37,11 @@ jchk "every rule.tier ∈ tiers"     '(.tiers|keys) as $t | all((.rules//[])[]; 
 jchk "every rule.pattern non-empty" 'all((.rules//[])[]; (.pattern|type=="string") and (.pattern|length>0))'
 
 # ── every regex compiles (ERE) + ReDoS lint ───────────────────────────────────────
-mapfile -t PATTERNS < <(jq -r '[ (.rules//[])[].pattern, (.rules//[])[].unless//empty, (.domains//[])[].pattern ] | .[]' "$SPEC" 2>/dev/null)
+# bash 3.2 (macOS) has no mapfile/readarray — read into the array portably.
+PATTERNS=()
+while IFS= read -r _p; do PATTERNS+=("$_p"); done < <(jq -r '[ (.rules//[])[].pattern, (.rules//[])[].unless//empty, (.domains//[])[].pattern ] | .[]' "$SPEC" 2>/dev/null)
 bad_compile=0; redos=0
-for p in "${PATTERNS[@]}"; do
+for p in ${PATTERNS[@]+"${PATTERNS[@]}"}; do
   [ -n "$p" ] || continue
   printf '' | grep -E -- "$p" >/dev/null 2>&1; [ "$?" = 2 ] && { no "pattern does not compile: $p"; bad_compile=1; }
   # ReDoS tripwire: a quantified token nested inside a group that is itself quantified by * or +


### PR DESCRIPTION
Two fixes on top of the cache-aware-routing work that landed on main.

- **`router/validate.sh` portability** — it used `mapfile` (bash 4+); on macOS bash 3.2 the `PATTERNS` array was unbound under `set -u`, so `validate.sh` errored and `router/test.sh`'s "validate passes the shipped spec" case failed. CI runs on Linux/bash-4, which masked it. Replaced with a portable read loop + a `set -u` array guard. Now: validate **15/0**, router test **79/0**, shellcheck clean.
- **Doc pins → latest tag** — README + `alpha.md` release-pin examples updated from `v0.12.1` to the existing latest tag **v0.13.0**.

Gate: 11/11 green locally (doctor · shellcheck · router test · router validate · route eval · bench · check-mcp · check-actions · CLI tests · selftest · plugin sync).