### PR TITLE
ci(sdlc): raise stingy --max-turns (classify 4→6, security 8→16)

### DIFF
--- a/.github/workflows/sdlc-classify.yml
+++ b/.github/workflows/sdlc-classify.yml
@@ -41,7 +41,7 @@ jobs:
             - core: core library / business logic (default if mixed/unclear)
           claude_args: |
             --model haiku
-            --max-turns 4
+            --max-turns 6
             --max-budget-usd 0.30
             --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*)"
             --json-schema '{"type":"object","properties":{"domain":{"type":"string","enum":["ui","api","infra","docs","core"]}},"required":["domain"]}'

--- a/.github/workflows/sdlc-security.yml
+++ b/.github/workflows/sdlc-security.yml
@@ -47,6 +47,6 @@ jobs:
             REPO: ${{ github.repository }}   PR: #${{ github.event.pull_request.number }}
           claude_args: |
             --model opus
-            --max-turns 8
+            --max-turns 16
             --max-budget-usd 2.50
             --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*)"

--- a/sdlc/workflows/sdlc-classify.yml
+++ b/sdlc/workflows/sdlc-classify.yml
@@ -41,7 +41,7 @@ jobs:
             - core: core library / business logic (default if mixed/unclear)
           claude_args: |
             --model haiku
-            --max-turns 4
+            --max-turns 6
             --max-budget-usd 0.30
             --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*)"
             --json-schema '{"type":"object","properties":{"domain":{"type":"string","enum":["ui","api","infra","docs","core"]}},"required":["domain"]}'

--- a/sdlc/workflows/sdlc-security.yml
+++ b/sdlc/workflows/sdlc-security.yml
@@ -47,6 +47,6 @@ jobs:
             REPO: ${{ github.repository }}   PR: #${{ github.event.pull_request.number }}
           claude_args: |
             --model opus
-            --max-turns 8
+            --max-turns 16
             --max-budget-usd 2.50
             --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*)"


### PR DESCRIPTION
## Why

On PR #24 (a large, single-file diff) two SDLC review jobs failed — but **not** on auth or budget:

- `classify` → `error_max_turns` at `--max-turns 4`
- `security` → `error_max_turns` at `--max-turns 8` (cost **$0.24** of the $2.50 budget)

Both authenticated fine via `CLAUDE_CODE_OAUTH_TOKEN`. They simply ran out of turns (git diff → read → reason → emit verdict) before finishing. The empty `ANTHROPIC_API_KEY` seen in logs is an unused/commented path, not the cause.

## Change

Raise only the two stingy outliers; `--max-budget-usd` remains the real cost guardrail (a job still can't overspend):

| Job | max-turns |
|---|---|
| `sdlc-classify` | 4 → 6 |
| `sdlc-security` | 8 → 16 |

Audited all SDLC workflows: the rest run 12–30 turns and are healthy — left unchanged. These jobs are non-required, so this only stops spurious red Xs; it doesn't change the merge gate.