### PR TITLE
test: validate SDLC_BOT_TOKEN fix (DO NOT MERGE)

### DIFF
--- a/docs/_verify_token.md
+++ b/docs/_verify_token.md
@@ -1,0 +1,3 @@
+# scratch
+
+Throwaway to validate SDLC_BOT_TOKEN + labels on classify. Will be closed.


### PR DESCRIPTION
Throwaway to confirm classify's apply-label step now authenticates (SDLC_BOT_TOKEN re-set) and applies a domain:* label. Will be closed unmerged.