### PR TITLE
docs(readme): stronger pitch + dual-audience + multi-loop emphasis

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Anyone can say "safe" and "cheap." compass hands you the number — and lets you reproduce it in 30 seconds: guardrails **100/100** on a 61-case bypass corpus, a router measured **~61% cheaper** than all-Opus at ~98% quality, **signed releases you verify** in one command. One config you own for every agent, in every repo — not a service. No `curl | sh`, no telemetry. **You always merge.**
 
+*In plain terms: a tireless senior teammate for your AI coding agents — it reviews and fixes its own work, spends your money wisely, refuses the dangerous stuff, and still can't ship anything without your yes.*
+
 [![ci](https://github.com/dshakes/compass/actions/workflows/ci.yml/badge.svg)](https://github.com/dshakes/compass/actions/workflows/ci.yml)
 [![release](https://img.shields.io/github/v/release/dshakes/compass?color=8A63D2)](https://github.com/dshakes/compass/releases)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
@@ -20,7 +22,7 @@ Anyone can say "safe" and "cheap." compass hands you the number — and lets you
 </p>
 
 <p align="center">
-  <b><a href="#install">Install ↓</a></b> &nbsp;·&nbsp; <a href="#see-it-work">▶ watch it fix its own PR</a> &nbsp;·&nbsp; <a href="docs/11-using-compass.md">📚 start here</a> &nbsp;·&nbsp; <a href="#whats-in-the-box">What's in the box</a> &nbsp;·&nbsp; <a href="#docs">Docs</a>
+  <a href="#-the-part-people-screenshot-it-fixes-its-own-prs">▶ Watch it fix its own PR</a> &nbsp;·&nbsp; <a href="#why-its-different--measured-not-vibes">Why it's different</a> &nbsp;·&nbsp; <a href="#loops-all-the-way-up">The loops</a> &nbsp;·&nbsp; <b><a href="#install">Install</a></b> &nbsp;·&nbsp; <a href="#whats-in-the-box">What's in the box</a> &nbsp;·&nbsp; <a href="docs/11-using-compass.md">📚 Docs</a>
 </p>
 
 ---
@@ -31,7 +33,7 @@ Anyone can say "safe" and "cheap." compass hands you the number — and lets you
 
 Open a pull request and compass **reviews it, security-checks it, runs the tests, cross-audits it with a second model — then pushes its own fixes until it's green.** You just merge.
 
-**Why it works: the loop is the unit of work.** A one-shot agent stops at its first wrong answer. compass *loops* — **generate → test → critique → fix → repeat against a gate** — so quality comes from iteration, not from one lucky prompt. That same closed loop drives every PR, every scheduled fleet run, and every parallel workflow. *(Try it locally in 30 seconds, no tokens — [watch the loop ↓](#see-it-work).)*
+**The idea in one line: the loop is the unit of work.** A one-shot agent stops at its first wrong answer. compass *loops* — **generate → test → critique → fix → repeat against a gate** — so quality comes from iteration, not one lucky prompt. The same closed loop runs a single PR, or your whole fleet of repos overnight. *(Try it locally in 30s, no tokens — [watch it ↓](#see-it-work).)*
 
 </div>
 
@@ -39,29 +41,80 @@ Open a pull request and compass **reviews it, security-checks it, runs the tests
 
 ## Why it's different — measured, not vibes
 
-Every AI-agent config claims "safe" and "cheap." compass is the one that hands you the **number** — and lets a skeptic reproduce it in 30 seconds. Everyone has the same models; the edge is *configuration you can trust*, not another feature list.
+Every AI-agent config claims "safe" and "cheap." compass is the one that hands you the **number** — and lets a skeptic reproduce it in 30 seconds. Everyone has the same models; the edge is *configuration you can trust*, not another feature list. Three claims, three commands:
 
-**🛡 Guardrails with a score.** Catastrophic commands and secret writes are blocked *before they run* — and the policy is eval-gated, not asserted:
+**🛡 Guardrails with a score.** Catastrophic commands and secret writes are blocked *before they run* — and the policy is eval-gated, not asserted. *(In human terms: it won't let the agent delete your machine or leak your keys, and it can prove how well.)*
 
 ```bash
 compass bench     # → guardrail 100% precision/recall (61-case corpus), router 96.9% — in CI
 # then ask the agent to `rm -rf /` or write a .env → denied; `rm -rf ./build` → allowed
 ```
 
-**📉 Cost routing that's measured.** Cheap work goes to cheap models — scored against an eval set, ~61% cheaper than all-Opus at ~98% quality on a fair mix:
+**📉 Cost routing that's measured.** Cheap work goes to cheap models — scored against an eval set, ~61% cheaper than all-Opus at ~98% quality on a fair mix. *(In human terms: it stops paying Opus prices to fix a typo.)*
 
 ```bash
 compass route "redesign the auth model"   # → opus
 compass route "fix a typo"                 # → haiku
 ```
 
-**🔏 Supply chain you can verify.** Releases carry keyless SLSA provenance, so a tampered or look-alike download is rejected:
+**🔏 Supply chain you can verify.** Releases carry keyless SLSA provenance, so a tampered or look-alike download is rejected. *(In human terms: you can prove the code you installed is the code I shipped.)*
 
 ```bash
 compass verify v0.14.0     # → ✓ provenance verified
 ```
 
 No service, no telemetry, no `--dangerously-skip-permissions`; `git pull` to update. The work it can't safely own, it hands back — **you keep the merge.**
+
+---
+
+## See it work
+
+Three views, smallest leap of faith first — **feel it**, then **see the proof**, then **see how it works.**
+
+**1 · The day-to-day feel** — guardrails, the cost-aware status line, the loop, and the crew, in ~25 seconds:
+
+<p align="center">
+  <img src="demo/preview.gif" alt="Terminal demo: compass blocks 'rm -rf /' (red) while 'rm -rf ./build' is allowed (green), shows the cost-aware status line, then the autonomous PR loop — review · security · tests · Codex audit → BLOCKING auto-fixes on the branch and re-reviews → CLEAN → you merge." width="800">
+</p>
+
+**2 · The headline, on a real PR** — a Blocking bug and red tests, and it pushes its *own* fix until the PR is green (then waits for you):
+
+<p align="center">
+  <img src="assets/loop.gif" alt="The loop on a real PR: Reviewer flags a bug as Blocking + QA red → the Builder pushes a fix commit → re-review goes CLEAN, QA green → mergeable, awaiting your code-owner approval." width="820">
+</p>
+
+**3 · How that loop works** — review · security · tests · Codex cross-audit run in parallel; Blocking findings get auto-fixed and re-reviewed (round-capped) until green, then it stops at you:
+
+<p align="center">
+  <img src="assets/sdlc-loop.svg" alt="Autonomous SDLC loop: push a PR → Reviewer, Auditor (Codex), Security, QA run in parallel → BLOCKING labels agent:needs-fix → the Builder fixes on the branch and pushes → re-review (round cap ×3) → CLEAN → checks green → human merge gate → you merge." width="860">
+</p>
+
+<p align="center"><sub>Run it locally in 30s with <code>~/compass/sdlc/orchestrate.sh "&lt;task&gt;"</code> (no tokens), or wire the GitHub loop for every PR. → <a href="docs/09-sdlc.md">how it works</a> · <a href="sdlc/SMOKETEST.md">reproduce it</a></sub></p>
+
+And the everyday status line quietly keeps score, so you watch it earn its keep:
+```text
+Opus 4.8 · myrepo · main* · 45k ctx · $1.23 · 🧭 🛡1 🧹2 💡1 📉~$1.65
+```
+<sub>session spend, then today's compass activity: **🛡** footguns blocked · **🧹** files formatted · **💡** policy nudges · **📉~$** estimated saved vs all-Opus. Each piece shows only when there's something to report; nothing leaves your machine.</sub>
+
+---
+
+## Loops all the way up
+
+Autonomy here isn't one big magic button — it's the *same closed loop* applied at four scales. Each runs until a gate says "done," then stops at a human. That's the whole trick: **iteration under a gate beats a single confident guess.**
+
+| | Loop | What it drives | Where it stops |
+|---|---|---|---|
+| 🔁 | **The task loop** | generate → test → critique → fix → repeat — one change driven to green | when tests + review pass |
+| 🔎 | **The review loop** | review → auto-fix the Blocking findings → re-review, round-capped (×3) | hands off to a human if still red |
+| 🛰️ | **The fleet loop** | the whole pipeline, scheduled across *every repo you own*, overnight, test-gated | a PR per repo, **approve from your phone** |
+| 👥 | **The workflow loops** | parallel agents that fan out, fact-check each other, and converge | one synthesized answer |
+
+Every loop ends the same way — **you merge.** That gate never moves.
+
+<p align="center">
+  <img src="assets/fleet.svg" alt="The fleet: a scheduler fans governed agents across many repos in parallel; each runs the review → test → fix loop on its own branch, opens a PR, and waits at the human approval gate — approvable from your phone." width="860">
+</p>
 
 ---
 
@@ -100,58 +153,25 @@ Then just open Claude Code as usual — the manual, guardrails, subagents, comma
 
 ---
 
-## See it work
-
-<p align="center">
-  <img src="demo/preview.gif" alt="Terminal demo: compass blocks 'rm -rf /' (red) while 'rm -rf ./build' is allowed (green), shows the cost-aware status line, then the autonomous PR loop — review · security · tests · Codex audit → BLOCKING auto-fixes on the branch and re-reviews → CLEAN → you merge." width="780">
-</p>
-<p align="center"><sub>Guardrails · cost-aware status line · the self-fixing loop · the crew — in ~25 seconds.</sub></p>
-
-The autonomous loop, as architecture and on a real PR:
-
-<p align="center">
-  <img src="assets/sdlc-loop.svg" alt="Autonomous SDLC loop: push a PR → Reviewer, Auditor (Codex), Security, QA run in parallel → BLOCKING labels agent:needs-fix → the Builder fixes on the branch and pushes → re-review (round cap ×3) → CLEAN → checks green → human merge gate → you merge." width="860">
-</p>
-<p align="center">
-  <img src="assets/loop.gif" alt="The loop on a real PR: Reviewer flags a bug as Blocking + QA red → the Builder pushes a fix commit → re-review goes CLEAN, QA green → mergeable, awaiting your code-owner approval." width="800">
-</p>
-<p align="center"><sub>Review · security · tests · Codex cross-audit → auto-fixes its own Blocking findings → green → <b>you merge</b>. Run it locally in 30s with <code>~/compass/sdlc/orchestrate.sh "&lt;task&gt;"</code> (no tokens), or wire the GitHub loop for every PR. → <a href="docs/09-sdlc.md">how it works</a> · <a href="sdlc/SMOKETEST.md">reproduce it</a></sub></p>
-
-The everyday status line quietly keeps score so you can see it earning its keep:
-```text
-Opus 4.8 · myrepo · main* · 45k ctx · $1.23 · 🧭 🛡1 🧹2 💡1 📉~$1.65
-```
-<sub>session spend, then today's compass activity: **🛡** footguns blocked · **🧹** files formatted · **💡** policy nudges · **📉~$** estimated saved vs all-Opus (once spend is logged). Each piece shows only when there's something to report; nothing leaves your machine.</sub>
-
----
-
 ## What's in the box
+
+Everything below is **on after one install** or a single opt-in — the autonomous loops above sit on top of this. The README sells; the docs explain — each row links to the detail.
 
 <p align="center">
   <img src="assets/hardening-frontier.svg" alt="The whole compass stack: a guarded base (manual · guardrail/secret/format/audit hooks · cost-tiered router) under a frontier layer of closed loops — the autonomous SDLC pipeline, the scheduled fleet, and parallel dynamic workflows — all ending at a permanent human merge/deploy gate." width="900">
 </p>
 
-Everything below is **on after one install** or a single opt-in. The README sells; the docs explain — each row links to the detail.
-
-**The top three are loops** — they don't answer once, they iterate against a gate until it passes, then hand you the result:
-
 | | Capability | One line | Deep dive |
 |---|---|---|---|
-| 🔁 | **Autonomous SDLC** *(loop)* | review → security → tests → Codex cross-audit → **auto-fixes its own Blocking findings** → re-reviews → green; you merge | [09-sdlc](docs/09-sdlc.md) |
-| 🛰️ | **The fleet** *(scheduled loop)* | governed agents patch/test/de-flake *all* your repos through a test gate on a schedule; approve from your phone | [14-fleet](docs/14-fleet.md) |
-| 👥 | **The crew + workflows** *(parallel loops)* | 10 cost-tiered subagents · 12 slash-commands · 3 dynamic workflows that fan out, fact-check each other, and converge | [12](docs/12-every-agent.md) · [13](docs/13-workflows.md) |
-| 🛡 | **Guardrails & scanning** | 4 hooks block disasters, catch secrets (write-hook + `compass scan`), auto-format, and keep a JSONL audit log | [16-hardening](docs/16-hardening-and-frontier.md) |
-| 🧭 | **Cost-tier router** | a standalone, reusable module — keyword heuristic → optional local classifier → Haiku judge cascade; eval-gated | [router/](router/) |
+| 🔁 | **Autonomous SDLC** | the review → security → tests → Codex audit → **auto-fix → re-review** loop; you merge | [09-sdlc](docs/09-sdlc.md) |
+| 🛰️ | **The fleet** | the loop, scheduled across *all* your repos through a test gate; approve from your phone | [14-fleet](docs/14-fleet.md) |
+| 👥 | **The crew + workflows** | 10 cost-tiered subagents · 12 slash-commands · 3 dynamic workflows that fact-check each other | [12](docs/12-every-agent.md) · [13](docs/13-workflows.md) |
+| 🛡 | **Guardrails & scanning** | 4 hooks block disasters, catch secrets (write-hook + `compass scan`), auto-format, keep a JSONL audit log | [16-hardening](docs/16-hardening-and-frontier.md) |
+| 🧭 | **Cost-tier router** | a standalone, reusable module — keyword heuristic → optional classifier → Haiku judge cascade; eval-gated | [router/](router/) |
 | 🧰 | **The compass CLI** | `onboard · impact · drift · scan · sandbox · verify · audit-log · spend · dashboard` | [11-using](docs/11-using-compass.md) |
 | 🔌 | **MCP + LSP** | curated, **version-pinned** MCP servers (context7 · fetch · git) + opt-in language-server intelligence | [04](docs/04-mcp.md) · [06](docs/06-lsp.md) |
 | 🪪 | **Every agent, one source** | Claude Code · Codex · Gemini — plus Cursor/Windsurf/Copilot via the [`AGENTS.md`](https://agents.md/) standard | [12-every-agent](docs/12-every-agent.md) |
-| 💰 | **Cost discipline** | model routing scored & CI-gated, per-step budget caps, `compass spend`/`impact` to see the $ | [02-cost](docs/02-cost-and-models.md) |
-
-The fleet is the loop pointed at *every* repo you own — one scheduled run, reviewed and test-gated, waiting for your approval:
-
-<p align="center">
-  <img src="assets/fleet.svg" alt="The fleet: a scheduler fans governed agents across many repos in parallel; each runs the review → test → fix loop on its own branch, opens a PR, and waits at the human approval gate — approvable from your phone." width="860">
-</p>
+| 💰 | **Cost discipline** | routing scored & CI-gated, per-step budget caps, `compass spend`/`impact` to see the $ | [02-cost](docs/02-cost-and-models.md) |
 
 ---
 


### PR DESCRIPTION
Second README pass per feedback: more engaging/attractive, reach both **influential engineers and a broader audience**, fix story + diagram order, and **emphasize the multiple loops**, the autonomy, cost, and guardrails.

## What changed
- **Dual audience.** Engineer proofs stay (numbers + reproducible commands); added a one-line human framing in the hero and *"in human terms"* notes on each proof, so a non-specialist gets it without diluting the technical pitch.
- **New section — "Loops all the way up."** Makes the multi-loop story explicit: the **task loop**, the **review loop** (round-capped auto-fix), the **fleet loop** (scheduled across all repos), and the **workflow loops** — each ending at *you merge*. The fleet diagram now sits next to the loops it illustrates.
- **Reordered "See it work" diagrams** into a narrative — smallest leap of faith first: `preview.gif` (feel it) → `loop.gif` (proof on a real PR) → `sdlc-loop.svg` (how it works).
- **Story order tightened**; all six diagrams kept; honest alpha framing + human merge gate intact. No "world-class".

## Checks
- nav anchors all resolve to headings; 21 internal links + 6 image assets exist
- 198 lines