### PR TITLE
ci(sdlc): classify labels via GITHUB_TOKEN (drop bot-PAT dependency)

### DIFF
--- a/.github/workflows/sdlc-classify.yml
+++ b/.github/workflows/sdlc-classify.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  issues: write          # labels are an issues resource — needed to apply domain:*
   pull-requests: write
   id-token: write
 
@@ -47,7 +48,9 @@ jobs:
             --json-schema '{"type":"object","properties":{"domain":{"type":"string","enum":["ui","api","infra","docs","core"]}},"required":["domain"]}'
       - name: Apply the domain label
         env:
-          GH_TOKEN: ${{ secrets.SDLC_BOT_TOKEN || github.token }}
+          # classify only LABELS (never pushes), so the built-in GITHUB_TOKEN is enough —
+          # no dependency on SDLC_BOT_TOKEN. Needs issues:write (granted above).
+          GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
           OUT: ${{ steps.classify.outputs.structured_output }}
         run: |

--- a/sdlc/workflows/sdlc-classify.yml
+++ b/sdlc/workflows/sdlc-classify.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  issues: write          # labels are an issues resource — needed to apply domain:*
   pull-requests: write
   id-token: write
 
@@ -47,7 +48,9 @@ jobs:
             --json-schema '{"type":"object","properties":{"domain":{"type":"string","enum":["ui","api","infra","docs","core"]}},"required":["domain"]}'
       - name: Apply the domain label
         env:
-          GH_TOKEN: ${{ secrets.SDLC_BOT_TOKEN || github.token }}
+          # classify only LABELS (never pushes), so the built-in GITHUB_TOKEN is enough —
+          # no dependency on SDLC_BOT_TOKEN. Needs issues:write (granted above).
+          GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
           OUT: ${{ steps.classify.outputs.structured_output }}
         run: |


### PR DESCRIPTION
classify only *labels* a PR (never pushes), so it doesn't need `SDLC_BOT_TOKEN`. Depending on that fine-grained PAT made it fail with `Resource not accessible by personal access token (addLabelsToLabelable)` whenever the PAT lacked Issues:write — verified on throwaway PRs #28/#30/#31, where the App-token-based `review` job labeled fine on the same PRs.

**Fix:** apply the label with the built-in `GITHUB_TOKEN` + grant `issues: write`. Least privilege, no external secret, no PAT-scope fragility. Template + `.github` mirror updated together; actions audit green (15/15).