### PR TITLE
ci(sdlc): robust reviewer diff-fetch + allow bot-triggered fix

### DIFF
--- a/.github/workflows/sdlc-fix.yml
+++ b/.github/workflows/sdlc-fix.yml
@@ -107,6 +107,10 @@ jobs:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # This job is triggered by the Reviewer's bot applying `agent:needs-fix`, so the
+          # actor is a Bot — claude-code-action refuses bot-initiated runs unless told to
+          # allow them. The trigger is our own gated label (same-repo only), so allow bots.
+          allowed_bots: "*"
           # PAT so the resulting push re-triggers sdlc-review.yml (closing the loop).
           github_token: ${{ steps.apptoken.outputs.token || secrets.SDLC_BOT_TOKEN || github.token }}
           prompt: |

--- a/.github/workflows/sdlc-review.yml
+++ b/.github/workflows/sdlc-review.yml
@@ -69,14 +69,21 @@ jobs:
           github_token: ${{ steps.apptoken.outputs.token || github.token }}
           prompt: |
             You are **Reviewer** (agent:review) in an autonomous SDLC pipeline.
-            Review ONLY the changes in this pull request for correctness, security,
+
+            GET THE DIFF with these exact commands (the full history is checked out, so
+            they always work — do NOT use any other tool to fetch the PR or its metadata;
+            if a command prints nothing, treat the change set as empty and return CLEAN):
+              git diff --name-only ${{ github.event.pull_request.base.sha }}...HEAD
+              git diff ${{ github.event.pull_request.base.sha }}...HEAD
+
+            Review ONLY those changes for correctness, security,
             and adherence to the repo's CLAUDE.md / AGENTS.md conventions.
             Post a SINGLE summary comment grouped Blocking / Should-fix / Nit, each as
             `path:line — issue — fix`. Do NOT post per-line inline review comments
             (they are turn-expensive and can exhaust the turn budget) and do NOT modify files.
 
             SPEC CHECK (intent, not just implementation): if this PR is spec-driven — a
-            `specs/*.md` file appears in `git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD`,
+            `specs/*.md` file appears in `git diff --name-only ${{ github.event.pull_request.base.sha }}...HEAD`,
             or the PR description has a `Spec: <path>` line — READ that spec and verify the diff
             satisfies every Acceptance Criterion and respects its Non-goals. Treat an unmet
             criterion or an out-of-scope change as **Blocking**.

--- a/sdlc/workflows/sdlc-fix.yml
+++ b/sdlc/workflows/sdlc-fix.yml
@@ -107,6 +107,10 @@ jobs:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # This job is triggered by the Reviewer's bot applying `agent:needs-fix`, so the
+          # actor is a Bot — claude-code-action refuses bot-initiated runs unless told to
+          # allow them. The trigger is our own gated label (same-repo only), so allow bots.
+          allowed_bots: "*"
           # PAT so the resulting push re-triggers sdlc-review.yml (closing the loop).
           github_token: ${{ steps.apptoken.outputs.token || secrets.SDLC_BOT_TOKEN || github.token }}
           prompt: |

--- a/sdlc/workflows/sdlc-review.yml
+++ b/sdlc/workflows/sdlc-review.yml
@@ -69,14 +69,21 @@ jobs:
           github_token: ${{ steps.apptoken.outputs.token || github.token }}
           prompt: |
             You are **Reviewer** (agent:review) in an autonomous SDLC pipeline.
-            Review ONLY the changes in this pull request for correctness, security,
+
+            GET THE DIFF with these exact commands (the full history is checked out, so
+            they always work — do NOT use any other tool to fetch the PR or its metadata;
+            if a command prints nothing, treat the change set as empty and return CLEAN):
+              git diff --name-only ${{ github.event.pull_request.base.sha }}...HEAD
+              git diff ${{ github.event.pull_request.base.sha }}...HEAD
+
+            Review ONLY those changes for correctness, security,
             and adherence to the repo's CLAUDE.md / AGENTS.md conventions.
             Post a SINGLE summary comment grouped Blocking / Should-fix / Nit, each as
             `path:line — issue — fix`. Do NOT post per-line inline review comments
             (they are turn-expensive and can exhaust the turn budget) and do NOT modify files.
 
             SPEC CHECK (intent, not just implementation): if this PR is spec-driven — a
-            `specs/*.md` file appears in `git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD`,
+            `specs/*.md` file appears in `git diff --name-only ${{ github.event.pull_request.base.sha }}...HEAD`,
             or the PR description has a `Spec: <path>` line — READ that spec and verify the diff
             satisfies every Acceptance Criterion and respects its Non-goals. Treat an unmet
             criterion or an out-of-scope change as **Blocking**.


### PR DESCRIPTION
Two fixes for the non-required bot jobs that were red on every PR:

- review: the Reviewer sometimes returned BLOCKING with "no tool permission to fetch PR diff/metadata" — it reached for a PR-fetch tool not in allowedTools instead of using git. Pin the diff to the always-present base SHA and instruct it to use only `git diff <base.sha>...HEAD` (no other fetch tool); also switch the spec-check path to the base SHA.
- fix: the job is triggered by the Reviewer's bot applying agent:needs-fix, so claude-code-action refused it ("Workflow initiated by non-human actor"). Add allowed_bots: "*" — the trigger is our own gated, same-repo label.

Templates + .github mirrors in sync (actions audit green).

<!-- Thanks for contributing to compass. Keep PRs focused. -->

## What & why
<!-- What changed and the reason. Link any issue. -->

## How I verified
- [ ] `make doctor` reports **0 errors**
- [ ] If I touched `claude/{agents,commands,skills,output-styles,hooks}`, I ran `make sync-plugin`
- [ ] Hooks (if changed) still never fail a session (only an intentional PreToolUse `exit 2` blocks)
- [ ] Docs/commands I changed still run; paths referenced exist

## Notes
<!-- Tradeoffs, follow-ups, anything a reviewer should know. -->
