### PR TITLE
ci: bump actions/checkout 6.0.2→6.0.3 (template+mirror)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install tooling
         run: sudo apt-get update -qq && sudo apt-get install -y -qq jq shellcheck

--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -19,7 +19,7 @@ jobs:
   attest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Fetch the release source tarball (what users + Homebrew download)
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0     # full history so the tag + CHANGELOG parsing work
 

--- a/.github/workflows/sdlc-audit.yml
+++ b/.github/workflows/sdlc-audit.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event.action != 'labeled' || github.event.label.name == 'agent:audit'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Review the merge result of an untrusted PR safely.
           ref: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/sdlc-classify.yml
+++ b/.github/workflows/sdlc-classify.yml
@@ -23,12 +23,12 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Classify the change
         id: classify
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/sdlc-classify.yml
+++ b/.github/workflows/sdlc-classify.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
       - name: Classify the change
         id: classify
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/sdlc-design-review.yml
+++ b/.github/workflows/sdlc-design-review.yml
@@ -20,11 +20,11 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Claude design review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/sdlc-design-review.yml
+++ b/.github/workflows/sdlc-design-review.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude design review
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/sdlc-fix.yml
+++ b/.github/workflows/sdlc-fix.yml
@@ -77,7 +77,7 @@ jobs:
           fi
       - name: Checkout PR head
         if: steps.cap.outputs.proceed == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -102,7 +102,7 @@ jobs:
           echo "gathered $(wc -l < "$f") lines of feedback → $f"
       - name: Claude fix
         if: steps.cap.outputs.proceed == 'true'
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-fix.yml
+++ b/.github/workflows/sdlc-fix.yml
@@ -102,7 +102,7 @@ jobs:
           echo "gathered $(wc -l < "$f") lines of feedback → $f"
       - name: Claude fix
         if: steps.cap.outputs.proceed == 'true'
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-implement-on-label.yml
+++ b/.github/workflows/sdlc-implement-on-label.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           app-id: ${{ vars.SDLC_APP_ID }}
           private-key: ${{ secrets.SDLC_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ steps.apptoken.outputs.token || secrets.SDLC_BOT_TOKEN || github.token }}
@@ -80,7 +80,7 @@ jobs:
           echo "path=$f" >> "$GITHUB_OUTPUT"
           echo "captured issue #$ISSUE → $f"
       - name: Claude implement → open PR
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-implement-on-label.yml
+++ b/.github/workflows/sdlc-implement-on-label.yml
@@ -80,7 +80,7 @@ jobs:
           echo "path=$f" >> "$GITHUB_OUTPUT"
           echo "captured issue #$ISSUE → $f"
       - name: Claude implement → open PR
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-implement.yml
+++ b/.github/workflows/sdlc-implement.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude implement
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits). For a pay-per-use key, replace with:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-implement.yml
+++ b/.github/workflows/sdlc-implement.yml
@@ -49,11 +49,11 @@ jobs:
         with:
           app-id: ${{ vars.SDLC_APP_ID }}
           private-key: ${{ secrets.SDLC_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Claude implement
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits). For a pay-per-use key, replace with:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-plan.yml
+++ b/.github/workflows/sdlc-plan.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude plan
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-plan.yml
+++ b/.github/workflows/sdlc-plan.yml
@@ -16,11 +16,11 @@ jobs:
     if: github.event.label.name == 'agent:plan'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Claude plan
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-qa.yml
+++ b/.github/workflows/sdlc-qa.yml
@@ -24,7 +24,7 @@ jobs:
     name: qa               # stable check name — referenced by branch-protection required checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Run test suite

--- a/.github/workflows/sdlc-release.yml
+++ b/.github/workflows/sdlc-release.yml
@@ -19,13 +19,13 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: ${{ secrets.SDLC_BOT_TOKEN || github.token }}
       - name: Claude release prep
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-release.yml
+++ b/.github/workflows/sdlc-release.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.SDLC_BOT_TOKEN || github.token }}
       - name: Claude release prep
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-review.yml
+++ b/.github/workflows/sdlc-review.yml
@@ -55,7 +55,7 @@ jobs:
           permission-pull-requests: write
       - name: Claude review
         id: review
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits) via `claude setup-token`.
           # To use a pay-per-use API key instead, replace the line below with:

--- a/.github/workflows/sdlc-review.yml
+++ b/.github/workflows/sdlc-review.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       # Org-wide bot identity (optional): if SDLC_APP_ID is set (a GitHub App installed on the
@@ -55,7 +55,7 @@ jobs:
           permission-pull-requests: write
       - name: Claude review
         id: review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits) via `claude setup-token`.
           # To use a pay-per-use API key instead, replace the line below with:

--- a/.github/workflows/sdlc-security.yml
+++ b/.github/workflows/sdlc-security.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude security review
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-security.yml
+++ b/.github/workflows/sdlc-security.yml
@@ -21,11 +21,11 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Claude security review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/release.yml
+++ b/sdlc/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0     # full history so the tag + CHANGELOG parsing work
 

--- a/sdlc/workflows/sdlc-audit.yml
+++ b/sdlc/workflows/sdlc-audit.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event.action != 'labeled' || github.event.label.name == 'agent:audit'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Review the merge result of an untrusted PR safely.
           ref: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/sdlc/workflows/sdlc-classify.yml
+++ b/sdlc/workflows/sdlc-classify.yml
@@ -23,12 +23,12 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Classify the change
         id: classify
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/sdlc/workflows/sdlc-classify.yml
+++ b/sdlc/workflows/sdlc-classify.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
       - name: Classify the change
         id: classify
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/sdlc/workflows/sdlc-design-review.yml
+++ b/sdlc/workflows/sdlc-design-review.yml
@@ -20,11 +20,11 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Claude design review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/sdlc/workflows/sdlc-design-review.yml
+++ b/sdlc/workflows/sdlc-design-review.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude design review
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/sdlc/workflows/sdlc-fix.yml
+++ b/sdlc/workflows/sdlc-fix.yml
@@ -77,7 +77,7 @@ jobs:
           fi
       - name: Checkout PR head
         if: steps.cap.outputs.proceed == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -102,7 +102,7 @@ jobs:
           echo "gathered $(wc -l < "$f") lines of feedback → $f"
       - name: Claude fix
         if: steps.cap.outputs.proceed == 'true'
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-fix.yml
+++ b/sdlc/workflows/sdlc-fix.yml
@@ -102,7 +102,7 @@ jobs:
           echo "gathered $(wc -l < "$f") lines of feedback → $f"
       - name: Claude fix
         if: steps.cap.outputs.proceed == 'true'
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-implement-on-label.yml
+++ b/sdlc/workflows/sdlc-implement-on-label.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           app-id: ${{ vars.SDLC_APP_ID }}
           private-key: ${{ secrets.SDLC_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ steps.apptoken.outputs.token || secrets.SDLC_BOT_TOKEN || github.token }}
@@ -80,7 +80,7 @@ jobs:
           echo "path=$f" >> "$GITHUB_OUTPUT"
           echo "captured issue #$ISSUE → $f"
       - name: Claude implement → open PR
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-implement-on-label.yml
+++ b/sdlc/workflows/sdlc-implement-on-label.yml
@@ -80,7 +80,7 @@ jobs:
           echo "path=$f" >> "$GITHUB_OUTPUT"
           echo "captured issue #$ISSUE → $f"
       - name: Claude implement → open PR
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-implement.yml
+++ b/sdlc/workflows/sdlc-implement.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude implement
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits). For a pay-per-use key, replace with:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-implement.yml
+++ b/sdlc/workflows/sdlc-implement.yml
@@ -49,11 +49,11 @@ jobs:
         with:
           app-id: ${{ vars.SDLC_APP_ID }}
           private-key: ${{ secrets.SDLC_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Claude implement
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits). For a pay-per-use key, replace with:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-plan.yml
+++ b/sdlc/workflows/sdlc-plan.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude plan
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-plan.yml
+++ b/sdlc/workflows/sdlc-plan.yml
@@ -16,11 +16,11 @@ jobs:
     if: github.event.label.name == 'agent:plan'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Claude plan
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-qa.yml
+++ b/sdlc/workflows/sdlc-qa.yml
@@ -24,7 +24,7 @@ jobs:
     name: qa               # stable check name — referenced by branch-protection required checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Run test suite

--- a/sdlc/workflows/sdlc-release.yml
+++ b/sdlc/workflows/sdlc-release.yml
@@ -19,13 +19,13 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: ${{ secrets.SDLC_BOT_TOKEN || github.token }}
       - name: Claude release prep
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-release.yml
+++ b/sdlc/workflows/sdlc-release.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.SDLC_BOT_TOKEN || github.token }}
       - name: Claude release prep
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-review.yml
+++ b/sdlc/workflows/sdlc-review.yml
@@ -55,7 +55,7 @@ jobs:
           permission-pull-requests: write
       - name: Claude review
         id: review
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits) via `claude setup-token`.
           # To use a pay-per-use API key instead, replace the line below with:

--- a/sdlc/workflows/sdlc-review.yml
+++ b/sdlc/workflows/sdlc-review.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       # Org-wide bot identity (optional): if SDLC_APP_ID is set (a GitHub App installed on the
@@ -55,7 +55,7 @@ jobs:
           permission-pull-requests: write
       - name: Claude review
         id: review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits) via `claude setup-token`.
           # To use a pay-per-use API key instead, replace the line below with:

--- a/sdlc/workflows/sdlc-security.yml
+++ b/sdlc/workflows/sdlc-security.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude security review
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-security.yml
+++ b/sdlc/workflows/sdlc-security.yml
@@ -21,11 +21,11 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Claude security review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Takes the safe Dependabot bump the right way for this repo's mirror model.

- `actions/checkout` 6.0.2 → **6.0.3** — applied to **both** `sdlc/workflows/` templates and `.github/workflows/` mirrors (audit 15/15), so no drift.

**Deferred:** the `anthropics/claude-code-action` bump (Dependabot #22). v1.0.134 adds an internal app-token exchange that requires a `github_token` (or a workflow matching the default branch) — it fails `classify`/`security` as currently configured. Keeping the validated SHA until those jobs are updated to pass a token.

Supersedes #23; #22 deferred.