### PR TITLE
ci(sdlc): adopt claude-code-action v1.0.134 (+github_token everywhere)

### DIFF
--- a/.github/workflows/sdlc-classify.yml
+++ b/.github/workflows/sdlc-classify.yml
@@ -28,9 +28,12 @@ jobs:
           fetch-depth: 0
       - name: Classify the change
         id: classify
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # claude-code-action v1.0.134+ does an app-token exchange that requires a token
+          # (or a workflow matching the default branch); pass the built-in one explicitly.
+          github_token: ${{ github.token }}
           prompt: |
             You are **Classifier** (agent:classify). Look at this PR's diff
             (`git diff origin/${{ github.event.pull_request.base.ref }}...HEAD`) and pick the

--- a/.github/workflows/sdlc-design-review.yml
+++ b/.github/workflows/sdlc-design-review.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  issues: write # claude-code-action posts its review comment via the Issues API
   pull-requests: write
   id-token: write
 
@@ -24,9 +25,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude design review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # claude-code-action v1.0.134+ does an app-token exchange that requires a token
+          # (or a workflow matching the default branch); pass the built-in one explicitly.
+          github_token: ${{ github.token }}
           prompt: |
             You are **Design Reviewer** (agent:design) for a UI/frontend change.
             Review ONLY this PR's diff for: accessibility (a11y, semantics, focus, contrast),

--- a/.github/workflows/sdlc-fix.yml
+++ b/.github/workflows/sdlc-fix.yml
@@ -102,7 +102,7 @@ jobs:
           echo "gathered $(wc -l < "$f") lines of feedback → $f"
       - name: Claude fix
         if: steps.cap.outputs.proceed == 'true'
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-implement-on-label.yml
+++ b/.github/workflows/sdlc-implement-on-label.yml
@@ -80,7 +80,7 @@ jobs:
           echo "path=$f" >> "$GITHUB_OUTPUT"
           echo "captured issue #$ISSUE → $f"
       - name: Claude implement → open PR
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-implement.yml
+++ b/.github/workflows/sdlc-implement.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude implement
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits). For a pay-per-use key, replace with:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-plan.yml
+++ b/.github/workflows/sdlc-plan.yml
@@ -20,11 +20,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude plan
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # claude-code-action v1.0.134+ does an app-token exchange that requires a token
+          # (or a workflow matching the default branch); pass the built-in one explicitly.
+          github_token: ${{ github.token }}
           prompt: |
             You are **Planner** (agent:plan) in an autonomous SDLC pipeline.
             Read issue #${{ github.event.issue.number }} with `gh issue view ${{ github.event.issue.number }}`,

--- a/.github/workflows/sdlc-release.yml
+++ b/.github/workflows/sdlc-release.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.SDLC_BOT_TOKEN || github.token }}
       - name: Claude release prep
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-review.yml
+++ b/.github/workflows/sdlc-review.yml
@@ -55,7 +55,7 @@ jobs:
           permission-pull-requests: write
       - name: Claude review
         id: review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits) via `claude setup-token`.
           # To use a pay-per-use API key instead, replace the line below with:

--- a/.github/workflows/sdlc-security.yml
+++ b/.github/workflows/sdlc-security.yml
@@ -36,6 +36,12 @@ jobs:
           github_token: ${{ github.token }}
           prompt: |
             You are **Security** (agent:security) in an autonomous SDLC pipeline.
+
+            GET THE DIFF with `git diff ${{ github.event.pull_request.base.sha }}...HEAD`
+            (the full history is checked out, so it always works — do NOT use any other tool
+            to fetch the PR). Read only the changed hunks plus the files they touch; do not
+            wander the whole repo.
+
             Audit ONLY this PR's changes for security issues: authn/authz gaps, IDOR,
             multi-tenant leaks, secrets in code/logs, injection (SQL/command/template),
             unsafe deserialization, widened trust boundaries, weak crypto, missing input

--- a/.github/workflows/sdlc-security.yml
+++ b/.github/workflows/sdlc-security.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  issues: write # claude-code-action posts the findings comment via the Issues API
   pull-requests: write
   id-token: write
 
@@ -25,11 +26,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude security review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # claude-code-action v1.0.134+ does an app-token exchange that requires a token
+          # (or a workflow matching the default branch); pass the built-in one explicitly.
+          github_token: ${{ github.token }}
           prompt: |
             You are **Security** (agent:security) in an autonomous SDLC pipeline.
             Audit ONLY this PR's changes for security issues: authn/authz gaps, IDOR,

--- a/sdlc/workflows/sdlc-classify.yml
+++ b/sdlc/workflows/sdlc-classify.yml
@@ -28,9 +28,12 @@ jobs:
           fetch-depth: 0
       - name: Classify the change
         id: classify
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # claude-code-action v1.0.134+ does an app-token exchange that requires a token
+          # (or a workflow matching the default branch); pass the built-in one explicitly.
+          github_token: ${{ github.token }}
           prompt: |
             You are **Classifier** (agent:classify). Look at this PR's diff
             (`git diff origin/${{ github.event.pull_request.base.ref }}...HEAD`) and pick the

--- a/sdlc/workflows/sdlc-design-review.yml
+++ b/sdlc/workflows/sdlc-design-review.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  issues: write # claude-code-action posts its review comment via the Issues API
   pull-requests: write
   id-token: write
 
@@ -24,9 +25,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude design review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # claude-code-action v1.0.134+ does an app-token exchange that requires a token
+          # (or a workflow matching the default branch); pass the built-in one explicitly.
+          github_token: ${{ github.token }}
           prompt: |
             You are **Design Reviewer** (agent:design) for a UI/frontend change.
             Review ONLY this PR's diff for: accessibility (a11y, semantics, focus, contrast),

--- a/sdlc/workflows/sdlc-fix.yml
+++ b/sdlc/workflows/sdlc-fix.yml
@@ -102,7 +102,7 @@ jobs:
           echo "gathered $(wc -l < "$f") lines of feedback → $f"
       - name: Claude fix
         if: steps.cap.outputs.proceed == 'true'
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-implement-on-label.yml
+++ b/sdlc/workflows/sdlc-implement-on-label.yml
@@ -80,7 +80,7 @@ jobs:
           echo "path=$f" >> "$GITHUB_OUTPUT"
           echo "captured issue #$ISSUE → $f"
       - name: Claude implement → open PR
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-implement.yml
+++ b/sdlc/workflows/sdlc-implement.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude implement
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits). For a pay-per-use key, replace with:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-plan.yml
+++ b/sdlc/workflows/sdlc-plan.yml
@@ -20,11 +20,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude plan
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # claude-code-action v1.0.134+ does an app-token exchange that requires a token
+          # (or a workflow matching the default branch); pass the built-in one explicitly.
+          github_token: ${{ github.token }}
           prompt: |
             You are **Planner** (agent:plan) in an autonomous SDLC pipeline.
             Read issue #${{ github.event.issue.number }} with `gh issue view ${{ github.event.issue.number }}`,

--- a/sdlc/workflows/sdlc-release.yml
+++ b/sdlc/workflows/sdlc-release.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.SDLC_BOT_TOKEN || github.token }}
       - name: Claude release prep
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-review.yml
+++ b/sdlc/workflows/sdlc-review.yml
@@ -55,7 +55,7 @@ jobs:
           permission-pull-requests: write
       - name: Claude review
         id: review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits) via `claude setup-token`.
           # To use a pay-per-use API key instead, replace the line below with:

--- a/sdlc/workflows/sdlc-security.yml
+++ b/sdlc/workflows/sdlc-security.yml
@@ -36,6 +36,12 @@ jobs:
           github_token: ${{ github.token }}
           prompt: |
             You are **Security** (agent:security) in an autonomous SDLC pipeline.
+
+            GET THE DIFF with `git diff ${{ github.event.pull_request.base.sha }}...HEAD`
+            (the full history is checked out, so it always works — do NOT use any other tool
+            to fetch the PR). Read only the changed hunks plus the files they touch; do not
+            wander the whole repo.
+
             Audit ONLY this PR's changes for security issues: authn/authz gaps, IDOR,
             multi-tenant leaks, secrets in code/logs, injection (SQL/command/template),
             unsafe deserialization, widened trust boundaries, weak crypto, missing input

--- a/sdlc/workflows/sdlc-security.yml
+++ b/sdlc/workflows/sdlc-security.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  issues: write # claude-code-action posts the findings comment via the Issues API
   pull-requests: write
   id-token: write
 
@@ -25,11 +26,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Claude security review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # claude-code-action v1.0.134+ does an app-token exchange that requires a token
+          # (or a workflow matching the default branch); pass the built-in one explicitly.
+          github_token: ${{ github.token }}
           prompt: |
             You are **Security** (agent:security) in an autonomous SDLC pipeline.
             Audit ONLY this PR's changes for security issues: authn/authz gaps, IDOR,


### PR DESCRIPTION
The deferred bump, done right. v1.0.134 adds an internal app-token exchange that needs a `github_token` (or a workflow matching the default branch) — that's why `classify`/`security` fast-failed on the earlier attempt (#35) while `review` (which passes a token) was fine.

**Changes**
- Pass `github_token: ${{ github.token }}` to **all** claude-code-action steps that lacked it: `classify`, `security`, `plan`, `design-review`.
- Grant `issues: write` where the action posts a comment: `security`, `design-review`.
- Bump `anthropics/claude-code-action` → **v1.0.134** across templates + mirrors (audit 15/15).

This PR **self-validates**: `classify`, `security`, and `review` run on the new action here. Merge once they're green. Supersedes Dependabot #22.