### PR TITLE
chore(release): v0.15.0 — red-team hardening layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.15.0] — 2026-06-05
+
+Red-team hardening — a measured, defense-in-depth layer that defends the agent itself
+against adversarial input, not just accidental footguns. Plugin manifests `0.15.0`.
+
+### Added
+
+- **Red-team hardening layer** ([ADR-0005](docs/adr/0005-red-team-hardening.md),
+  [docs/17](docs/17-red-team.md)). Detects, warns on, and audits: direct + **indirect**
+  + copy/paste **prompt injection**, **CLAUDE.md/AGENTS.md context poisoning**, local
+  `.claude/settings.json` **safety-override**, **malware authoring** (awareness, dual-use
+  aware), and **insecure code** (SAST-lite). Pure detectors in `claude/hooks/lib/policy.sh`
+  (`injection_findings`, `settings_override_reason`, `malware_intent_findings`,
+  `insecure_code_findings`).
+- **Eval + golden corpus** — `scripts/redteam-corpus.tsv` (56 + 4 programmatic = 60) scored
+  by `scripts/test-redteam.sh`; **precision 100% / recall 100%** (floors 100/90), gated in
+  CI via `compass doctor`. `COMPASS_REDTEAM_CORPUS` runs your own labeled corpus.
+- **Runtime hooks** (warn + audit by default): `scan-untrusted-context.sh` (SessionStart),
+  `scan-prompt.sh` (UserPromptSubmit), `scan-tool-output.sh` (PostToolUse) — wired in
+  `claude/settings.json` and the plugin bundle.
+- **CLI** — `compass redteam [--eval|--scan|--json]` and `compass scan --injection`.
+- **Optional managed-guardrail escalation** (`COMPASS_GUARDRAIL_BACKEND`): `webhook`
+  (verifiable shape) · `bedrock` · `azure` Prompt Shields. NOTE: the Bedrock/Azure adapters
+  are written to-spec but **UNVERIFIED against live endpoints** — validate with your creds.
+- **Feature flags** — `COMPASS_REDTEAM`, `_PROMPT`, `_TOOL_OUTPUT`, `_CONTEXT`, `_ENFORCE`.
+
+### Changed
+
+- **Operating manual** (`claude/CLAUDE.md`) hard lines: external content is data, not
+  instructions; a project cannot grant itself a safety exception; no weaponization.
+
 ## [0.14.0] — 2026-06-02
 
 Cache-aware routing + prompt-cache TTL — the router now folds Anthropic prompt-cache

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ compass route "fix a typo"                 # → haiku
 **🔏 Supply chain you can verify.** Releases carry keyless SLSA provenance, so a tampered or look-alike download is rejected. *(In human terms: you can prove the code you installed is the code I shipped.)*
 
 ```bash
-compass verify v0.14.0     # → ✓ provenance verified
+compass verify v0.15.0     # → ✓ provenance verified
 ```
 
 **🧪 Red-team resistance, measured.** Prompt-injection (direct/indirect/paste), CLAUDE.md poisoning, local safety-override, malware & insecure-code — scored against a labeled corpus that gates in CI, with optional escalation to a managed guardrails service (webhook · Bedrock · Azure). *(In human terms: a poisoned repo or web page can't quietly turn your agent against you.)*
@@ -138,7 +138,7 @@ compass quickstart                       # previews, asks, then wires it into ~/
 **📦 Git clone** — own & edit your config *(recommended)*
 ```bash
 git clone https://github.com/dshakes/compass ~/compass && cd ~/compass
-git checkout v0.14.0     # optional: pin to a release instead of main
+git checkout v0.15.0     # optional: pin to a release instead of main
 ./quickstart.sh          # previews every change, asks first, fully reversible
 ```
 

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -66,7 +66,7 @@ Lead with the claim a reviewer can confirm in 30 seconds, not the loop.
 > 1. `git clone https://github.com/dshakes/compass ~/compass && cd ~/compass && make install && make doctor` (expect `0 error`).
 > 2. In Claude Code, ask it to run `rm -rf $HOME` or write a `.env` → **blocked before it runs**; `rm -rf ./build` is allowed. (`compass audit-log` shows the block.)
 > 3. `compass bench` → guardrail **100% precision/recall on a 61-case corpus**, router **96.9%** — reproducible, CI-gated.
-> 4. `compass verify v0.14.0` → confirms the release's keyless SLSA provenance.
+> 4. `compass verify v0.15.0` → confirms the release's keyless SLSA provenance.
 > 5. `compass route "fix a typo"` → `haiku`; `compass route "redesign the auth model"` → `opus` — the cache-aware cost-tier router (ADR-0004), runnable standalone from `router/`.
 > 6. *(Optional, needs a GitHub repo + token)* the autonomous PR loop's logic is statically validated in CI (`make doctor` + the GitHub-Actions audit `scripts/check-actions.sh`); reproduce the live behavior with the checklist in `sdlc/SMOKETEST.md`. The same loop runs **scheduled across many repos** as the *fleet* (`docs/14-fleet.md`).
 
@@ -78,7 +78,11 @@ Lead with the claim a reviewer can confirm in 30 seconds, not the loop.
 > safety layer with a published precision/recall number, **cost routing that's measured not
 > asserted**, and **SLSA supply-chain provenance** for the config itself — directly answering
 > the marketplace-plugin-hijack concerns of 2026.
-> **Newest (v0.14.0):** the router is a **reusable, cache-aware module** (`router/`, ADR-0004)
+> **Newest (v0.15.0):** a **red-team hardening layer** ([ADR-0005](docs/adr/0005-red-team-hardening.md),
+> [docs/17](docs/17-red-team.md)) — eval-gated defense (100% P/R on a labeled corpus) against
+> prompt-injection (direct/indirect/paste), CLAUDE.md poisoning, local safety-override, malware,
+> and insecure code; `compass redteam` + optional Bedrock/Azure/webhook backend. Also (v0.14.0):
+> the router is a **reusable, cache-aware module** (`router/`, ADR-0004)
 > with a heuristic → optional-classifier → LLM-judge cascade; and the autonomous loop scales
 > from one PR to a **scheduled fleet across every repo you own** — governed, test-gated, with
 > approve-from-your-phone notifications. None of the comparable plugins do measured-safety +

--- a/plugins/core-lsp/.claude-plugin/plugin.json
+++ b/plugins/core-lsp/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "core-lsp",
   "displayName": "Core — LSP",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Language-server intelligence (diagnostics, navigation) for Go, Rust, TypeScript, and Python. Opt-in companion to core — requires the language servers installed on PATH.",
   "author": {
     "name": "Shekhar Mudarapu",

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "core",
   "displayName": "Core",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Cost-tiered specialist subagents, workflow commands, guardrail + auto-quality hooks, a repo-bootstrap skill, a terse output style, and parity MCP servers — for serious polyglot software work.",
   "author": {
     "name": "Shekhar Mudarapu",


### PR DESCRIPTION
Version bump for the release. Ships the **red-team hardening layer** (PR #37) to users.

- Plugin manifests → `0.15.0`
- CHANGELOG `[0.15.0]` section (injection/override/malware/insecure-code detectors, eval-gated 100% P/R, hooks, `compass redteam`, optional webhook/Bedrock/Azure backend — the last two labeled UNVERIFIED-live)
- README + launch-kit version refs → v0.15.0

After merge, `scripts/release.sh v0.15.0` tags, pins the Homebrew formula sha, publishes the GitHub release, and triggers SLSA signing.