### PR TITLE
feat(vendor): native Gemini CLI extension + one-source cross-vendor packaging (Wave 1)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+claude/CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ git checkout v0.16.0     # optional: pin to a release instead of main
 
 **🛠️ By hand:** `make dry-run` (preview) → `make install` → `make doctor`. Symlink install means `git pull`/`brew upgrade` updates everything; `make uninstall` removes only what it added. → [Team rollout](docs/05-plugin.md)
 
+### One config, every agent — native installs
+The same operating manual + MCP servers, the way each tool expects them:
+
+| Agent | Install | Loads |
+|---|---|---|
+| **Claude Code** | `/plugin install core@compass` (or `make install`) | `~/.claude/CLAUDE.md` + hooks + agents + commands + MCP |
+| **Gemini CLI** | `gemini extensions install https://github.com/dshakes/compass` | `gemini-extension.json` → `GEMINI.md` + context7/fetch/git MCP |
+| **Codex** | `make install` (symlinks `~/.codex/AGENTS.md`) | `AGENTS.md` + `config.toml` profiles + MCP |
+| **Cursor · Copilot · OpenCode · Windsurf** | clone + `make install`; they read the repo's `AGENTS.md` | `AGENTS.md` (the [AGENTS.md](https://agents.md/) standard) |
+
+`AGENTS.md` and `GEMINI.md` are one file — symlinks of the same manual, so a `git pull` updates every agent at once.
+
 ### ✅ Verify → your first run
 ```bash
 compass doctor      # validate the install — expect "0 error"

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -2,9 +2,10 @@
 
 The shared constitution for AI coding assistants in my environment — how I work,
 what I optimize for, and the lines I don't cross. Loaded by Claude Code (as
-`CLAUDE.md`) and, via a symlinked `AGENTS.md`, by Codex and other AGENTS.md-aware
-tools — one source of truth for both. Project-level files add specifics and
-**override** anything here on conflict.
+`CLAUDE.md`), by Codex and other AGENTS.md-aware tools (via a symlinked `AGENTS.md`),
+and by Gemini CLI (as `GEMINI.md` / the compass Gemini extension) — one source of
+truth for all of them. Project-level files add specifics and **override** anything
+here on conflict.
 
 Keep this short. A bloated memory file dilutes the signal and gets ignored; if a
 rule isn't earning its place in the context window, cut it.

--- a/docs/05-plugin.md
+++ b/docs/05-plugin.md
@@ -25,6 +25,29 @@ Local testing from a clone:
 /plugin install core@compass
 ```
 
+## Other agents — native installs (one source)
+
+The operating manual and the version-pinned MCP servers are shared across agents, each
+in the format that tool expects — kept in sync by symlinks + `scripts/check-vendor.sh`:
+
+```bash
+# Gemini CLI — native extension (gemini-extension.json → GEMINI.md + context7/fetch/git MCP)
+gemini extensions install https://github.com/dshakes/compass
+
+# Codex — symlinks ~/.codex/AGENTS.md + config.toml profiles
+make install            # or ./install.sh --codex-only
+
+# Gemini global context instead of the extension: ~/.gemini/GEMINI.md
+./install.sh --gemini
+
+# Cursor · Copilot · OpenCode · Windsurf — read the repo's AGENTS.md (the agents.md standard)
+make install            # clone first; AGENTS.md is a symlink of the same manual
+```
+
+`GEMINI.md`, `AGENTS.md`, and `CLAUDE.md` are **one file** (symlinks). `gemini-extension.json`'s
+version + MCP servers are CI-checked against `plugins/core` and `mcp/servers.json` so a vendor
+manifest can never silently drift from the real config.
+
 ## What the plugin delivers
 10 subagents · 12 commands · 4 hooks (incl. the `protect-paths` guardrail) ·
 `bootstrap-agent-config` skill · "Concise" output style ·

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -110,6 +110,7 @@ Lead with the claim a reviewer can confirm in 30 seconds, not the loop.
 
 | Channel | How | Notes |
 |---|---|---|
+| **Gemini CLI extension** | `gemini extensions install https://github.com/dshakes/compass` works **now** (`gemini-extension.json` → `GEMINI.md` + context7/fetch/git MCP). | Cross-vendor reach beyond Claude; same one-source manual. |
 | **claudemarketplaces.com** | Auto-crawls GitHub for a valid `.claude-plugin/marketplace.json` — **already valid** (name, owner, plugins[], pinned versions). Nothing to submit; optionally email `hi@claudemarketplaces.com`. | Discovery-based. |
 | **Chat2AnyLLM/awesome-claude-plugins** | PR-based awesome-list for plugins/marketplaces — add an entry. | Standard PR. |
 | **jeremylongshore/claude-code-plugins-plus-skills** (`ccpi`) | Submit repo link per its CONTRIBUTING / email `jeremy@intentsolutions.io`. | Accepted ones get featured. |

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,20 @@
+{
+  "name": "compass",
+  "version": "0.16.0",
+  "description": "compass — one operating manual + eval-gated guardrails, red-team hardening, a cost-tier router and signed config for your coding agent. Loads the manual as GEMINI.md and wires the same version-pinned MCP servers (context7 · fetch · git) compass uses for Claude Code and Codex.",
+  "contextFileName": "GEMINI.md",
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@3.1.0"]
+    },
+    "fetch": {
+      "command": "uvx",
+      "args": ["--from", "mcp-server-fetch==2025.4.7", "mcp-server-fetch"]
+    },
+    "git": {
+      "command": "uvx",
+      "args": ["--from", "mcp-server-git==2026.1.14", "mcp-server-git"]
+    }
+  }
+}

--- a/scripts/check-vendor.sh
+++ b/scripts/check-vendor.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# check-vendor.sh — keep the cross-vendor packaging honest and wired to ONE source.
+# Validates gemini-extension.json against the real compass sources (no mocks):
+#   • valid JSON, name "compass"
+#   • version == the plugin manifest version (plugins/core)
+#   • contextFileName GEMINI.md, present, and resolving to the operating manual
+#   • mcpServers == exactly the auto-registered stdio servers in mcp/servers.json,
+#     with identical command + args (the real pinned servers, not a copy that can drift)
+# Runs in CI via doctor. Exit 0 = clean, 1 = drift/invalid.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXT="$ROOT/gemini-extension.json"
+SRV="$ROOT/mcp/servers.json"
+PLUGIN="$ROOT/plugins/core/.claude-plugin/plugin.json"
+fail=0
+no() { printf '  \033[31m✗\033[0m %s\n' "$1"; fail=1; }
+ok() { printf '  \033[32mok\033[0m %s\n' "$1"; }
+
+command -v jq >/dev/null 2>&1 || { echo "check-vendor: jq required"; exit 0; }
+[ -f "$EXT" ] || { no "missing gemini-extension.json"; exit 1; }
+jq empty "$EXT" 2>/dev/null && ok "gemini-extension.json is valid JSON" || no "gemini-extension.json invalid JSON"
+
+[ "$(jq -r '.name' "$EXT")" = "compass" ] && ok "name = compass" || no "name must be 'compass'"
+
+vext="$(jq -r '.version' "$EXT")"; vplug="$(jq -r '.version' "$PLUGIN")"
+[ "$vext" = "$vplug" ] && ok "version $vext matches plugin manifest" || no "version drift: ext=$vext plugin=$vplug"
+
+cf="$(jq -r '.contextFileName' "$EXT")"
+if [ "$cf" = "GEMINI.md" ] && [ -e "$ROOT/GEMINI.md" ]; then
+  tgt="$(readlink "$ROOT/GEMINI.md" 2>/dev/null || echo)"
+  if [ "$tgt" = "claude/CLAUDE.md" ] || diff -q "$ROOT/GEMINI.md" "$ROOT/claude/CLAUDE.md" >/dev/null 2>&1; then
+    ok "contextFileName GEMINI.md resolves to the operating manual"
+  else no "GEMINI.md does not match the operating manual (claude/CLAUDE.md)"; fi
+else no "contextFileName must be GEMINI.md and the file must exist"; fi
+
+# mcpServers must equal the auto-registered stdio servers, byte-for-byte on command+args.
+want="$(jq -r '[.servers|to_entries[]|select(.value.autoRegister==true and .value.type=="stdio")|.key]|sort|join(",")' "$SRV")"
+have="$(jq -r '[.mcpServers|keys[]]|sort|join(",")' "$EXT")"
+if [ "$want" = "$have" ]; then ok "mcpServers = auto-registered stdio servers ($have)"
+else no "mcpServers drift: extension=[$have] vs servers.json auto-reg stdio=[$want]"; fi
+
+IFS=','; for k in $want; do
+  [ -n "$k" ] || continue
+  a="$(jq -Sc --arg k "$k" '.mcpServers[$k]|{command,args}' "$EXT" 2>/dev/null)"
+  b="$(jq -Sc --arg k "$k" '.servers[$k]|{command,args}' "$SRV" 2>/dev/null)"
+  [ "$a" = "$b" ] && ok "mcp '$k' command+args match servers.json" || no "mcp '$k' drift: ext=$a src=$b"
+done; unset IFS
+
+[ "$fail" -eq 0 ]

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -63,6 +63,10 @@ else fail "actions audit failed — run: scripts/check-actions.sh"; fi
 if "$REPO"/scripts/check-mcp.sh >/dev/null 2>&1; then pass "MCP manifest clean (version-pinned · no injection markers)"
 else fail "MCP manifest audit failed — run: scripts/check-mcp.sh"; fi
 
+# Cross-vendor packaging: the Gemini extension stays wired to one source (version + MCP).
+if "$REPO"/scripts/check-vendor.sh >/dev/null 2>&1; then pass "vendor manifests in sync (gemini-extension.json ↔ version · MCP · manual)"
+else fail "vendor manifest drift — run: scripts/check-vendor.sh"; fi
+
 # Guardrail policy: the bypass corpus must pass (the safety-critical eval).
 if "$REPO"/scripts/test-protect-paths.sh >/dev/null 2>&1; then pass "guardrail bypass corpus passes (protect-paths policy)"
 else fail "guardrail corpus failed — run: scripts/test-protect-paths.sh"; fi


### PR DESCRIPTION
Wave 1 of the multi-vendor work inspired by superpowers — **native installs, real not mocked**.

## What
- **`gemini-extension.json`** (the documented Gemini CLI extension spec) + root **`GEMINI.md`** (a symlink of the operating manual) → `gemini extensions install https://github.com/dshakes/compass` works natively, wiring the same version-pinned **context7 · fetch · git** MCP servers compass uses for Claude/Codex.
- **`scripts/check-vendor.sh`** (doctor-gated drift check): the manifest is CI-verified against the *real* sources — `version` == `plugins/core`, `contextFileName` resolves to the manual, and `mcpServers` == the auto-registered stdio servers in `mcp/servers.json` (command+args byte-equal). **A vendor manifest can't silently drift or be a mock.**
- **README**: a per-agent native-install table (Claude · Gemini · Codex · Cursor/Copilot/OpenCode/Windsurf via the real `AGENTS.md` standard). `docs/05` + launch-kit updated; manual header notes `GEMINI.md`.

## Honest scope (no fabrication)
- Gemini uses its **documented extension format** (verified against Google's docs).
- Codex/Cursor/Copilot/OpenCode use the **real `AGENTS.md` standard** compass already ships (symlinked manual) — I did **not** invent `.cursor-plugin`/`.codex-plugin` formats.
- `GEMINI.md`/`AGENTS.md`/`CLAUDE.md` are one file (symlinks) → `git pull` updates every agent.

## Verified
doctor **105 ok / 0 errors** (new vendor gate green); check-vendor 8/8; no regressions (red-team, guardrail, mcp, actions, plugin-sync all green); GEMINI.md tracked as a real symlink. No "world-class".

Waves 2 (skills dispatcher + trigger-first frontmatter) and 3 (methodology skills + compose-with-superpowers + README polish) follow in the same style.