### PR TITLE
docs: remove third-party project name (keep generic composition framing)

### DIFF
--- a/docs/15-competitive-audit.md
+++ b/docs/15-competitive-audit.md
@@ -355,21 +355,19 @@ because their value is in the black box and compass's is in the daylight.
 
 ---
 
-## Composing with Superpowers (obra/superpowers)
+## Composing with methodology / skill frameworks
 
-Superpowers is the popular *methodology* layer — composable skills that teach an agent
-*how to work* (TDD, brainstorming, systematic debugging, code review, git worktrees). It is
-**complementary to compass, not a competitor**, and we say so plainly:
+Skill-and-methodology frameworks teach an agent *how to work* (TDD, brainstorming, systematic
+debugging, code review, git worktrees). They are **complementary to compass, not competitors**:
 
 - **compass governs** — eval-gated guardrails, red-team hardening, a measured cost router,
   SLSA provenance, and a human-gated autonomous loop. *Is the agent safe, cheap, auditable?*
-- **Superpowers does methodology** — *how does the agent do the work well?*
+- **methodology frameworks** answer *how does the agent do the work well?*
 
-**Install both.** They share primitives (Claude-Code plugin, `SKILL.md`, subagents,
-AGENTS.md) and don't collide. What compass took from superpowers (credited): the
-**multi-vendor native-install** pattern (per-vendor manifests from one source — see the
-Gemini extension), the **`using-X` dispatcher** (`using-compass`), and the **trigger-first,
-enforceable `SKILL.md`** style (red-flags / verification checklists — see
-`verification-before-completion`, `systematic-debugging`). What we deliberately did **not**
-copy: the methodology framework itself — that's their owned position, and compass leads with
-measured safety + provenance instead.
+They share primitives (Claude-Code plugin, `SKILL.md`, subagents, AGENTS.md) and don't collide,
+so they compose. Patterns compass adopted from the broader ecosystem: **multi-vendor
+native-install** (per-vendor manifests from one source — see the Gemini extension), a
+**`using-compass` dispatcher** so the agent reaches for the right capability, and a
+**trigger-first, enforceable `SKILL.md`** style (red-flags / verification checklists — see
+`verification-before-completion`, `systematic-debugging`). What compass deliberately does **not**
+try to be: a methodology framework — it leads with measured safety + provenance instead.

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -126,8 +126,8 @@ Install path for all of them is already shipped: `/plugin marketplace add dshake
 > **compass — eval-gated guardrails + red-team hardening, a measured cost router, and signed
 > supply-chain for Claude Code, Codex & Gemini. Auditable config you own, not a service.**
 
-Do **not** lead with "turns your agent into a senior engineer" — that's Superpowers' owned
-position (~150k★). Lead with the three things the giants *don't* have: **measured safety**,
+Do **not** lead with "turns your agent into a senior engineer" — that's the crowded,
+well-owned skill-framework lane. Lead with the three things the giants *don't* have: **measured safety**,
 **red-team resistance you can reproduce**, and **provenance**. The self-fixing PR loop is the
 demo; the eval numbers (`compass bench`, `compass redteam`) and `compass verify` are the proof.
 
@@ -239,7 +239,7 @@ Link from README once live.
 
 | If they mention… | Lead with |
 |---|---|
-| **Superpowers** ("senior engineer" skills) | "Different aim — compass is the *measured safety + cost + provenance* layer; it composes with skill frameworks, doesn't replace them." |
+| **"senior engineer" skill frameworks** | "Different aim — compass is the *measured safety + cost + provenance* layer; it composes with skill frameworks, doesn't replace them." |
 | **spec-kit** | "compass has `/spec` and reads spec-kit's `spec.md`; it's a layer on top, not a competitor." |
 | **claude-router / cost tools** | "Ours is eval-scored + CI-gated with a reproducible cost-at-iso-quality number, **cache-aware** (ADR-0004), and a reusable module (`router/`)." |
 | **rulebricks / cloud guardrails** | "No service or cloud dependency — auditable files, `git pull` to update; the policy is a corpus-tested pure function." |


### PR DESCRIPTION
Per request: removes all mentions of the named external skill framework from docs/15 and launch-kit. Reframed generically ('methodology / skill frameworks') — compass composes with them and leads with measured safety + provenance. Docs-only, no behavioral change.