### PR TITLE
feat(vendor): native Codex plugin marketplace (Claude · Codex · Gemini parity)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "compass",
+  "interface": {
+    "displayName": "compass"
+  },
+  "plugins": [
+    {
+      "name": "core",
+      "source": {
+        "source": "local",
+        "path": "./plugins/core"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "NONE"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -155,16 +155,18 @@ git checkout v0.16.0     # optional: pin to a release instead of main
 **🛠️ By hand:** `make dry-run` (preview) → `make install` → `make doctor`. Symlink install means `git pull`/`brew upgrade` updates everything; `make uninstall` removes only what it added. → [Team rollout](docs/05-plugin.md)
 
 ### One config, every agent — native installs
-The same operating manual + MCP servers, the way each tool expects them:
+For *every* kind of user: a one-line marketplace/extension install (no terminal), or `make install` if you'd rather own the files. Same operating manual + MCP servers, the way each tool expects them:
 
-| Agent | Install | Loads |
+| Agent | Native install (no terminal) | or own the files |
 |---|---|---|
-| **Claude Code** | `/plugin install core@compass` (or `make install`) | `~/.claude/CLAUDE.md` + hooks + agents + commands + MCP |
-| **Gemini CLI** | `gemini extensions install https://github.com/dshakes/compass` | `gemini-extension.json` → `GEMINI.md` + context7/fetch/git MCP |
-| **Codex** | `make install` (symlinks `~/.codex/AGENTS.md`) | `AGENTS.md` + `config.toml` profiles + MCP |
-| **Cursor · Copilot · OpenCode · Windsurf** | clone + `make install`; they read the repo's `AGENTS.md` | `AGENTS.md` (the [AGENTS.md](https://agents.md/) standard) |
+| **Claude Code** | `/plugin marketplace add dshakes/compass` → `/plugin install core@compass` | `make install` |
+| **Codex** | `codex plugin marketplace add dshakes/compass` → `/plugin install` | `make install` (`~/.codex/AGENTS.md` + `config.toml`) |
+| **Gemini CLI** | `gemini extensions install https://github.com/dshakes/compass` | `./install.sh --gemini` (`~/.gemini/GEMINI.md`) |
+| **Cursor · Copilot · OpenCode · Windsurf** | read the repo's `AGENTS.md` ([AGENTS.md](https://agents.md/) standard) | clone + `make install` |
 
-`AGENTS.md` and `GEMINI.md` are one file — symlinks of the same manual, so a `git pull` updates every agent at once.
+`CLAUDE.md` · `AGENTS.md` · `GEMINI.md` are **one file** (symlinks), and the Claude/Codex plugin manifests + Gemini extension are generated from one source and CI-checked (`scripts/check-vendor.sh`) — so a `git pull` updates every agent at once and a manifest can't drift.
+
+> The marketplace/extension manifests match each vendor's documented schema and are structure-validated in CI; the live `…/plugin install` / `extensions install` step needs that vendor's CLI, which isn't run in our CI.
 
 ### ✅ Verify → your first run
 ```bash

--- a/docs/05-plugin.md
+++ b/docs/05-plugin.md
@@ -31,10 +31,13 @@ The operating manual and the version-pinned MCP servers are shared across agents
 in the format that tool expects — kept in sync by symlinks + `scripts/check-vendor.sh`:
 
 ```bash
+# Codex — native plugin marketplace (.codex-plugin/plugin.json + .agents/plugins/marketplace.json)
+codex plugin marketplace add dshakes/compass   # then: /plugin install  (browse with /plugins)
+
 # Gemini CLI — native extension (gemini-extension.json → GEMINI.md + context7/fetch/git MCP)
 gemini extensions install https://github.com/dshakes/compass
 
-# Codex — symlinks ~/.codex/AGENTS.md + config.toml profiles
+# Codex (own the files instead) — symlinks ~/.codex/AGENTS.md + config.toml profiles
 make install            # or ./install.sh --codex-only
 
 # Gemini global context instead of the extension: ~/.gemini/GEMINI.md

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -110,7 +110,8 @@ Lead with the claim a reviewer can confirm in 30 seconds, not the loop.
 
 | Channel | How | Notes |
 |---|---|---|
-| **Gemini CLI extension** | `gemini extensions install https://github.com/dshakes/compass` works **now** (`gemini-extension.json` → `GEMINI.md` + context7/fetch/git MCP). | Cross-vendor reach beyond Claude; same one-source manual. |
+| **Gemini CLI extension** | `gemini extensions install https://github.com/dshakes/compass` (`gemini-extension.json` → `GEMINI.md` + context7/fetch/git MCP). | Cross-vendor reach; same one-source manual. |
+| **Codex plugin marketplace** | `codex plugin marketplace add dshakes/compass` → `/plugin install` (`.codex-plugin/plugin.json` + `.agents/plugins/marketplace.json`). | Native Codex plugin, mirrors the Claude marketplace. |
 | **claudemarketplaces.com** | Auto-crawls GitHub for a valid `.claude-plugin/marketplace.json` — **already valid** (name, owner, plugins[], pinned versions). Nothing to submit; optionally email `hi@claudemarketplaces.com`. | Discovery-based. |
 | **Chat2AnyLLM/awesome-claude-plugins** | PR-based awesome-list for plugins/marketplaces — add an entry. | Standard PR. |
 | **jeremylongshore/claude-code-plugins-plus-skills** (`ccpi`) | Submit repo link per its CONTRIBUTING / email `jeremy@intentsolutions.io`. | Accepted ones get featured. |

--- a/plugins/core/.codex-plugin/plugin.json
+++ b/plugins/core/.codex-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "core",
+  "version": "0.16.0",
+  "description": "Cost-tiered specialist subagents, workflow commands, guardrail + red-team + auto-quality hooks, repo-bootstrap and using-compass skills, and parity MCP servers — for serious polyglot software work.",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "hooks": "./hooks/hooks.json",
+  "author": {
+    "name": "Shekhar Mudarapu",
+    "url": "https://github.com/dshakes"
+  },
+  "homepage": "https://github.com/dshakes/compass#readme",
+  "repository": "https://github.com/dshakes/compass",
+  "license": "MIT",
+  "keywords": ["subagents", "hooks", "code-review", "security-review", "red-team", "cost-optimization", "mcp"],
+  "interface": {
+    "displayName": "Core",
+    "category": "Developer Tools"
+  }
+}

--- a/scripts/check-vendor.sh
+++ b/scripts/check-vendor.sh
@@ -46,4 +46,27 @@ IFS=','; for k in $want; do
   [ "$a" = "$b" ] && ok "mcp '$k' command+args match servers.json" || no "mcp '$k' drift: ext=$a src=$b"
 done; unset IFS
 
+# ── Codex plugin + marketplace (mirrors the Claude plugin; same single source) ──
+CXP="$ROOT/plugins/core/.codex-plugin/plugin.json"
+MKT="$ROOT/.agents/plugins/marketplace.json"
+if [ -f "$CXP" ]; then
+  jq empty "$CXP" 2>/dev/null && ok "codex plugin.json is valid JSON" || no "codex plugin.json invalid JSON"
+  [ "$(jq -r '.name' "$CXP")" = "core" ] && ok "codex plugin name = core" || no "codex plugin name must be 'core'"
+  [ "$(jq -r '.version' "$CXP")" = "$vplug" ] && ok "codex plugin version matches ($vplug)" || no "codex plugin version drift"
+  # component pointers must resolve inside the plugin dir
+  for ptr in skills mcpServers hooks; do
+    p="$(jq -r --arg k "$ptr" '.[$k] // empty' "$CXP")"
+    [ -n "$p" ] || continue
+    [ -e "$ROOT/plugins/core/${p#./}" ] && ok "codex pointer $ptr → $p resolves" || no "codex pointer $ptr → $p missing"
+  done
+else no "missing plugins/core/.codex-plugin/plugin.json"; fi
+
+if [ -f "$MKT" ]; then
+  jq empty "$MKT" 2>/dev/null && ok "codex marketplace.json is valid JSON" || no "codex marketplace.json invalid JSON"
+  [ "$(jq -r '.plugins[0].name' "$MKT")" = "core" ] && ok "marketplace lists core" || no "marketplace must list plugin 'core'"
+  sp="$(jq -r '.plugins[0].source.path' "$MKT")"
+  if [ "$sp" = "./plugins/core" ] && [ -d "$ROOT/plugins/core" ]; then ok "marketplace source.path → ./plugins/core resolves"
+  else no "marketplace source.path must be ./plugins/core and exist"; fi
+else no "missing .agents/plugins/marketplace.json"; fi
+
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Makes compass installable as a **native plugin in Codex too** — matching the Claude plugin marketplace and the Gemini extension. Real, to OpenAI's documented schema; no mocks.

## What
- **`plugins/core/.codex-plugin/plugin.json`** — Codex manifest (`skills` · `mcpServers` → `.mcp.json` · `hooks` pointers), mirrors the Claude plugin from the same single `plugins/core` source.
- **`.agents/plugins/marketplace.json`** — Codex marketplace catalog → `./plugins/core`.
- **`scripts/check-vendor.sh`** now gates the Codex plugin + marketplace too (valid JSON, version == `plugins/core`, component pointers resolve, `source.path` resolves) — doctor-gated, so it can't drift or mock.
- **README** per-agent table now leads with **native, no-terminal installs** for every user type (Claude/Codex `plugin marketplace add`, Gemini `extensions install`) *and* a `make install` "own the files" column. docs/05 + launch-kit updated.

## Install (now)
```
codex plugin marketplace add dshakes/compass    # then /plugin install
gemini extensions install https://github.com/dshakes/compass
/plugin marketplace add dshakes/compass         # Claude → /plugin install core@compass
```

## Honest scope
Built to OpenAI's documented Codex plugin schema; structure-validated in CI (jq + drift check). The **live** `codex plugin marketplace add` / `gemini extensions install` needs that vendor's CLI, which isn't in our CI — stated in the README status. `policy.authentication: NONE` (compass needs no install-time auth) — adjust if a live Codex rejects the enum.

doctor **105 ok / 0 errors**; no regressions (red-team, actions, mcp, sync, vendor all green).