### PR TITLE
fix(codex): marketplace authentication ON_USE — v0.17.1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -12,7 +12,7 @@
       },
       "policy": {
         "installation": "AVAILABLE",
-        "authentication": "NONE"
+        "authentication": "ON_USE"
       },
       "category": "Developer Tools"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.17.1] — 2026-06-05
+
+### Fixed
+
+- **Codex marketplace install** — `.agents/plugins/marketplace.json` used
+  `policy.authentication: "NONE"`, which Codex rejects (`unknown variant NONE, expected
+  ON_INSTALL or ON_USE`), breaking `codex plugin marketplace add`. Set to `ON_USE` (compass
+  needs no install-time auth). **Verified live** with `codex 0.130.0` (add now succeeds) and
+  `gemini 0.26.0` (extension installs as `compass 0.17.x`). `scripts/check-vendor.sh` now
+  gates the authentication enum so this can't regress.
+
 ## [0.17.0] — 2026-06-05
 
 Cross-vendor native installs + the skills system. One config, every agent — a one-line

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ compass route "fix a typo"                 # → haiku
 **🔏 Supply chain you can verify.** Releases carry keyless SLSA provenance, so a tampered or look-alike download is rejected. *(In human terms: you can prove the code you installed is the code I shipped.)*
 
 ```bash
-compass verify v0.17.0     # → ✓ provenance verified
+compass verify v0.17.1     # → ✓ provenance verified
 ```
 
 **🧪 Red-team resistance, measured.** Prompt-injection (direct/indirect/paste), CLAUDE.md poisoning, local safety-override, malware & insecure-code — scored against a labeled corpus that gates in CI, with optional escalation to a managed guardrails service (webhook · Bedrock · Azure). *(In human terms: a poisoned repo or web page can't quietly turn your agent against you.)*
@@ -142,7 +142,7 @@ compass quickstart                       # previews, asks, then wires it into ~/
 **📦 Git clone** — own & edit your config *(recommended)*
 ```bash
 git clone https://github.com/dshakes/compass ~/compass && cd ~/compass
-git checkout v0.17.0     # optional: pin to a release instead of main
+git checkout v0.17.1     # optional: pin to a release instead of main
 ./quickstart.sh          # previews every change, asks first, fully reversible
 ```
 

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -67,7 +67,7 @@ Lead with the claim a reviewer can confirm in 30 seconds, not the loop.
 > 1. `git clone https://github.com/dshakes/compass ~/compass && cd ~/compass && make install && make doctor` (expect `0 error`).
 > 2. In Claude Code, ask it to run `rm -rf $HOME` or write a `.env` → **blocked before it runs**; `rm -rf ./build` is allowed. (`compass audit-log` shows the block.)
 > 3. `compass bench` → guardrail **100% precision/recall on a 61-case corpus**, router **96.9%** — reproducible, CI-gated.
-> 4. `compass verify v0.17.0` → confirms the release's keyless SLSA provenance.
+> 4. `compass verify v0.17.1` → confirms the release's keyless SLSA provenance.
 > 5. `compass route "fix a typo"` → `haiku`; `compass route "redesign the auth model"` → `opus` — the cache-aware cost-tier router (ADR-0004), runnable standalone from `router/`.
 > 6. `compass redteam` → injection corpus **100% precision/recall**; `compass redteam --attack` → **100% robustness** after base64/zero-width/homoglyph/leetspeak obfuscation; `compass redteam --scan` flags a poisoned `CLAUDE.md`. Eval-gated in CI ([docs/17](docs/17-red-team.md)).
 > 7. *(Optional, needs a GitHub repo + token)* the autonomous PR loop's logic is statically validated in CI (`make doctor` + the GitHub-Actions audit `scripts/check-actions.sh`); reproduce the live behavior with the checklist in `sdlc/SMOKETEST.md`. The same loop runs **scheduled across many repos** as the *fleet* (`docs/14-fleet.md`).
@@ -80,7 +80,7 @@ Lead with the claim a reviewer can confirm in 30 seconds, not the loop.
 > safety layer with a published precision/recall number, **cost routing that's measured not
 > asserted**, and **SLSA supply-chain provenance** for the config itself — directly answering
 > the marketplace-plugin-hijack concerns of 2026.
-> **Newest (v0.17.0):** **native installs across vendors** — compass is now a plugin in
+> **Newest (v0.17.1):** **native installs across vendors** — compass is now a plugin in
 > Claude Code, Codex (`codex plugin marketplace add dshakes/compass`), and a Gemini CLI
 > extension (`gemini extensions install …`), all generated from one source and CI-checked
 > (`scripts/check-vendor.sh`); plus a skills system (`using-compass` dispatcher,

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "compass",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "compass — one operating manual + eval-gated guardrails, red-team hardening, a cost-tier router and signed config for your coding agent. Loads the manual as GEMINI.md and wires the same version-pinned MCP servers (context7 · fetch · git) compass uses for Claude Code and Codex.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {

--- a/plugins/core-lsp/.claude-plugin/plugin.json
+++ b/plugins/core-lsp/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "core-lsp",
   "displayName": "Core — LSP",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Language-server intelligence (diagnostics, navigation) for Go, Rust, TypeScript, and Python. Opt-in companion to core — requires the language servers installed on PATH.",
   "author": {
     "name": "Shekhar Mudarapu",

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "core",
   "displayName": "Core",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Cost-tiered specialist subagents, workflow commands, guardrail + auto-quality hooks, a repo-bootstrap skill, a terse output style, and parity MCP servers — for serious polyglot software work.",
   "author": {
     "name": "Shekhar Mudarapu",

--- a/plugins/core/.codex-plugin/plugin.json
+++ b/plugins/core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Cost-tiered specialist subagents, workflow commands, guardrail + red-team + auto-quality hooks, repo-bootstrap and using-compass skills, and parity MCP servers — for serious polyglot software work.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/scripts/check-vendor.sh
+++ b/scripts/check-vendor.sh
@@ -64,6 +64,9 @@ else no "missing plugins/core/.codex-plugin/plugin.json"; fi
 if [ -f "$MKT" ]; then
   jq empty "$MKT" 2>/dev/null && ok "codex marketplace.json is valid JSON" || no "codex marketplace.json invalid JSON"
   [ "$(jq -r '.plugins[0].name' "$MKT")" = "core" ] && ok "marketplace lists core" || no "marketplace must list plugin 'core'"
+  # policy.authentication must be a value Codex accepts (verified live: ON_INSTALL | ON_USE).
+  auth="$(jq -r '.plugins[0].policy.authentication' "$MKT")"
+  case "$auth" in ON_INSTALL|ON_USE) ok "marketplace authentication=$auth (valid Codex enum)" ;; *) no "marketplace authentication '$auth' invalid — must be ON_INSTALL or ON_USE" ;; esac
   sp="$(jq -r '.plugins[0].source.path' "$MKT")"
   if [ "$sp" = "./plugins/core" ] && [ -d "$ROOT/plugins/core" ]; then ok "marketplace source.path → ./plugins/core resolves"
   else no "marketplace source.path must be ./plugins/core and exist"; fi


### PR DESCRIPTION
**Real-bug fix found by the live smoke test** (codex 0.130.0): `policy.authentication: "NONE"` breaks `codex plugin marketplace add` (`unknown variant NONE, expected ON_INSTALL or ON_USE`). Set to **ON_USE** (compass needs no install-time auth). `scripts/check-vendor.sh` now gates the enum so it can't regress. Manifests → 0.17.1.

**Verified live, not mocked:** `codex plugin marketplace add` now succeeds; `gemini extensions install …` installs `compass 0.17.x` (all 3 MCP servers + GEMINI.md) and uninstalls clean. doctor 0 errors.