### PR TITLE
chore(security): gitleaks allowlist for test fixtures (clean external scan)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,23 @@
+# .gitleaks.toml — compass scan config for external secret scanners.
+#
+# compass's OWN gate is the built-in detector in claude/hooks/lib/policy.sh (deterministic,
+# allowlist-aware). This file makes `gitleaks` agree with it: the only hits are deliberate
+# FAKE, structured secret-shaped strings in test fixtures / labeled corpora (which exercise
+# the guardrail's secret detectors and the memory store's secret-dropping) and prompt text
+# (the classifier's "api=API/SDK"). There are no real secrets in this repo.
+title = "compass"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Intentional fake secrets in tests/corpora + classifier prompt text"
+paths = [
+  '''scripts/test-protect-paths\.sh''',
+  '''scripts/test-cli\.sh''',
+  '''scripts/test-redteam\.sh''',
+  '''scripts/test-guardrail-remote\.sh''',
+  '''scripts/.*-corpus\.tsv''',
+  '''mcp/compass-memory/test_store\.py''',
+  '''(^|/)sdlc-classify\.yml$''',
+]

--- a/scripts/compass-scan.sh
+++ b/scripts/compass-scan.sh
@@ -176,9 +176,10 @@ esac
 # --- Optional gitleaks depth pass (best-effort; never fails the run) ----------
 gl_note=""
 if have gitleaks; then
+  GLCFG=""; [ -f "$ROOT/.gitleaks.toml" ] && GLCFG="--config=$ROOT/.gitleaks.toml"
   case "$mode" in
-    staged|diff) gl_out="$(gitleaks git --no-banner --redact -v 2>/dev/null || true)" ;;
-    *)           gl_out="$(gitleaks dir --no-banner --redact -v "${paths[0]:-.}" 2>/dev/null || true)" ;;
+    staged|diff) gl_out="$(gitleaks git $GLCFG --no-banner --redact -v 2>/dev/null || true)" ;;
+    *)           gl_out="$(gitleaks dir $GLCFG --no-banner --redact -v "${paths[0]:-.}" 2>/dev/null || true)" ;;
   esac
   if printf '%s' "$gl_out" | grep -qiE 'secret|finding|rule:'; then
     gl_note="$(printf '%s\n' "$gl_out" | grep -iE 'Finding|RuleID|File|Secret' | sed 's/^/  gitleaks: /' | head -40)"


### PR DESCRIPTION
Pre-publicity hygiene: the repo has **no real secrets** (verified across the 166-commit history), but gitleaks' generic-api-key heuristic flagged 5 deliberate fake secret-shaped strings in test fixtures/corpora + the classifier prompt. Adds `.gitleaks.toml` (extends defaults) so anyone scanning the repo sees **no leaks found**; `compass scan` passes `--config` when present. `compass scan --all` → clean. doctor 0 errors.