### PR TITLE
chore(repo): gitignore local marketing/launch drafts (docs/blog/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ venv/
 # Backups created by the installer (these live under ~/.claude anyway)
 backups/
 
+# Marketing/launch drafts — kept locally, not part of the shipped repo
+docs/blog/
+
 # router module — generated model + per-app local overlay (never commit)
 router/classifier.model
 router/router.local.json


### PR DESCRIPTION
Adds `docs/blog/` to `.gitignore` so locally-kept LinkedIn / blog / Show HN drafts stay out of the shipped repo.

- One-line ignore rule; no content committed.
- `docs/blog/loop-is-my-unit-of-code.md` and `docs/blog/show-hn.md` exist locally only.

Verified: `git check-ignore` matches both files; `git status` shows neither.