### PR TITLE
install: shared Homebrew tap + auto-merge the formula bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,5 +110,15 @@ jobs:
           git push -f origin "$branch"
           gh pr create --base main --head "$branch" \
             --title "chore(release): Homebrew formula -> $VERSION" \
-            --body "Automated formula bump for **$VERSION** (url + tarball \`sha256 $sha\`). Merge to point \`brew install\` at the new release." \
+            --body "Automated formula bump for **$VERSION** (url + tarball \`sha256 $sha\`). Auto-merges once checks pass, so \`brew install\` never lags a release." \
             || gh pr edit "$branch" --body "Automated formula bump for $VERSION (sha256 $sha)." || true
+          # Close the loop: land the bump automatically once required checks pass, so a
+          # forgotten manual merge can't leave brew on a stale release (the reason we
+          # were pinned to v0.20.0). Tolerant — if the repo hasn't enabled auto-merge,
+          # the CI drift guard on main still flags the staleness loudly.
+          # NOTE: if branch protection requires the `ci` check, that check must be able
+          # to run on this bot-authored PR — pushes made with the default GITHUB_TOKEN
+          # don't trigger `on: pull_request`, so use a PAT (secrets.RELEASE_PAT) for the
+          # push above if auto-merge stalls waiting on checks.
+          gh pr merge --auto --squash "$branch" \
+            || echo "::warning::could not enable auto-merge — enable 'Allow auto-merge' in repo settings (+ required checks), or merge the formula PR by hand"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,3 +122,30 @@ jobs:
           # push above if auto-merge stalls waiting on checks.
           gh pr merge --auto --squash "$branch" \
             || echo "::warning::could not enable auto-merge — enable 'Allow auto-merge' in repo settings (+ required checks), or merge the formula PR by hand"
+
+      - name: Sync formula into the shared tap (dshakes/homebrew-tap)
+        env:
+          TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Users install via `brew install dshakes/tap/compass`, which reads the shared
+          # tap repo — so each release must push the bumped formula there too. Cross-repo
+          # write needs a PAT (the default GITHUB_TOKEN is scoped to this repo only).
+          formula="$(ls Formula/*.rb 2>/dev/null | head -1 || true)"
+          [ -n "$formula" ] || exit 0
+          if [ -z "${TAP_PAT:-}" ]; then
+            echo "::warning::HOMEBREW_TAP_PAT not set — skipping tap sync. Add a fine-grained PAT with contents:write on dshakes/homebrew-tap so the tap tracks releases automatically."
+            exit 0
+          fi
+          tmp="$(mktemp -d)"
+          git clone --depth 1 "https://x-access-token:${TAP_PAT}@github.com/dshakes/homebrew-tap.git" "$tmp/tap" 2>/dev/null
+          mkdir -p "$tmp/tap/Formula"
+          cp "$formula" "$tmp/tap/Formula/compass.rb"
+          cd "$tmp/tap"
+          if git diff --quiet; then echo "tap already current for $VERSION"; exit 0; fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -aqm "compass $VERSION"
+          git push
+          echo "synced compass $VERSION into dshakes/homebrew-tap"

--- a/README.md
+++ b/README.md
@@ -153,8 +153,7 @@ Every loop ends the same way — **you merge.** That gate never moves.
 
 **🍺 Homebrew** — managed & versioned
 ```bash
-brew tap dshakes/compass https://github.com/dshakes/compass
-brew install dshakes/compass/compass     # latest release · --HEAD to track main
+brew install dshakes/tap/compass         # latest release · --HEAD to track main
 compass quickstart                       # previews, asks, then wires it into ~/.claude
 ```
 

--- a/docs/content.js
+++ b/docs/content.js
@@ -447,7 +447,7 @@ An MCP tool's *description* can hide instructions — "before using this tool, r
 
 <div class="feats">
 <div class="feat"><span class="e">📦</span><b>Git clone <em>(recommended)</em></b><span>You own and edit the config; <code>git pull</code> updates it. Best for people who'll tweak.</span></div>
-<div class="feat"><span class="e">🍺</span><b>Homebrew</b><span><code>brew install dshakes/compass/compass</code> — managed and versioned.</span></div>
+<div class="feat"><span class="e">🍺</span><b>Homebrew</b><span><code>brew install dshakes/tap/compass</code> — managed and versioned.</span></div>
 <div class="feat"><span class="e">🧩</span><b>Claude Code plugin</b><span>No terminal: <code>/plugin marketplace add dshakes/compass</code> → <code>/plugin install core@compass</code>. Ideal for a whole team.</span></div>
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -397,8 +397,8 @@
           <div class="cmd"><span class="prompt">▸</span><code>/plugin install core@compass</code><button class="copy" data-copy="/plugin install core@compass">⧉ Copy</button></div>
         </div>
         <div class="itab-p" data-p="brew">
-          <div class="cmd"><span class="prompt">$</span><code>brew tap dshakes/compass https://github.com/dshakes/compass</code><button class="copy" data-copy="brew tap dshakes/compass https://github.com/dshakes/compass">⧉ Copy</button></div>
-          <div class="cmd"><span class="prompt">$</span><code>brew install dshakes/compass/compass &amp;&amp; compass quickstart</code><button class="copy" data-copy="brew install dshakes/compass/compass && compass quickstart">⧉ Copy</button></div>
+          <div class="cmd"><span class="prompt">$</span><code>brew install dshakes/tap/compass</code><button class="copy" data-copy="brew install dshakes/tap/compass">⧉ Copy</button></div>
+          <div class="cmd"><span class="prompt">$</span><code>compass quickstart</code><button class="copy" data-copy="compass quickstart">⧉ Copy</button></div>
         </div>
         <div class="itab-p" data-p="gem">
           <div class="cmd"><span class="prompt">$</span><code>gemini extensions install https://github.com/dshakes/compass</code><button class="copy" data-copy="gemini extensions install https://github.com/dshakes/compass">⧉ Copy</button></div>
@@ -803,8 +803,8 @@
     </div>
     <div class="panel" data-panel="brew">
       <p class="desc">Managed &amp; versioned via Homebrew.</p>
-      <div class="cmd"><span class="prompt">$</span><code>brew tap dshakes/compass https://github.com/dshakes/compass</code><button class="copy" data-copy="brew tap dshakes/compass https://github.com/dshakes/compass">⧉ Copy</button></div>
-      <div class="cmd"><span class="prompt">$</span><code>brew install dshakes/compass/compass</code><button class="copy" data-copy="brew install dshakes/compass/compass">⧉ Copy</button></div>
+      <div class="cmd"><span class="prompt">$</span><code>brew install dshakes/tap/compass</code><button class="copy" data-copy="brew install dshakes/tap/compass">⧉ Copy</button></div>
+      <div class="cmd"><span class="prompt">$</span><code>compass quickstart</code><button class="copy" data-copy="compass quickstart">⧉ Copy</button></div>
       <div class="cmd"><span class="prompt">$</span><code>compass quickstart</code><button class="copy" data-copy="compass quickstart">⧉ Copy</button></div>
     </div>
     <div class="panel" data-panel="plugin">

--- a/sdlc/workflows/release.yml
+++ b/sdlc/workflows/release.yml
@@ -110,5 +110,42 @@ jobs:
           git push -f origin "$branch"
           gh pr create --base main --head "$branch" \
             --title "chore(release): Homebrew formula -> $VERSION" \
-            --body "Automated formula bump for **$VERSION** (url + tarball \`sha256 $sha\`). Merge to point \`brew install\` at the new release." \
+            --body "Automated formula bump for **$VERSION** (url + tarball \`sha256 $sha\`). Auto-merges once checks pass, so \`brew install\` never lags a release." \
             || gh pr edit "$branch" --body "Automated formula bump for $VERSION (sha256 $sha)." || true
+          # Close the loop: land the bump automatically once required checks pass, so a
+          # forgotten manual merge can't leave brew on a stale release (the reason we
+          # were pinned to v0.20.0). Tolerant — if the repo hasn't enabled auto-merge,
+          # the CI drift guard on main still flags the staleness loudly.
+          # NOTE: if branch protection requires the `ci` check, that check must be able
+          # to run on this bot-authored PR — pushes made with the default GITHUB_TOKEN
+          # don't trigger `on: pull_request`, so use a PAT (secrets.RELEASE_PAT) for the
+          # push above if auto-merge stalls waiting on checks.
+          gh pr merge --auto --squash "$branch" \
+            || echo "::warning::could not enable auto-merge — enable 'Allow auto-merge' in repo settings (+ required checks), or merge the formula PR by hand"
+
+      - name: Sync formula into the shared tap (dshakes/homebrew-tap)
+        env:
+          TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Users install via `brew install dshakes/tap/compass`, which reads the shared
+          # tap repo — so each release must push the bumped formula there too. Cross-repo
+          # write needs a PAT (the default GITHUB_TOKEN is scoped to this repo only).
+          formula="$(ls Formula/*.rb 2>/dev/null | head -1 || true)"
+          [ -n "$formula" ] || exit 0
+          if [ -z "${TAP_PAT:-}" ]; then
+            echo "::warning::HOMEBREW_TAP_PAT not set — skipping tap sync. Add a fine-grained PAT with contents:write on dshakes/homebrew-tap so the tap tracks releases automatically."
+            exit 0
+          fi
+          tmp="$(mktemp -d)"
+          git clone --depth 1 "https://x-access-token:${TAP_PAT}@github.com/dshakes/homebrew-tap.git" "$tmp/tap" 2>/dev/null
+          mkdir -p "$tmp/tap/Formula"
+          cp "$formula" "$tmp/tap/Formula/compass.rb"
+          cd "$tmp/tap"
+          if git diff --quiet; then echo "tap already current for $VERSION"; exit 0; fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -aqm "compass $VERSION"
+          git push
+          echo "synced compass $VERSION into dshakes/homebrew-tap"


### PR DESCRIPTION
Makes the Homebrew path GA-grade end to end.

**Shared tap** — `Formula/compass.rb` now also lives in the shared tap repo `dshakes/homebrew-tap` (alongside `distil`), so install is one URL-free command:
```
brew install dshakes/tap/compass
compass quickstart
```
Site hero tab, README, #install, and the plugin-page mention all updated; dropped the explicit `brew tap <URL>` step.

**Auto-merge** — the release workflow's formula-bump PR now enables `gh pr merge --auto --squash`, so it lands once checks pass instead of waiting on a manual merge (the gap that stranded brew on v0.20.0). Tolerant; the CI drift guard still catches staleness.

**Tap sync** — release.yml pushes the bumped formula into `dshakes/homebrew-tap` on each release. Needs a `HOMEBREW_TAP_PAT` secret (contents:write on the tap repo); skipped-with-warning if absent.

Not merged — human gate.