### PR TITLE
release: v1.0.0 (first stable) + action bumps; closes Dependabot #58/#59/#62/#65

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install tooling
         run: sudo apt-get update -qq && sudo apt-get install -y -qq jq shellcheck

--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -19,7 +19,7 @@ jobs:
   attest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Fetch the release source tarball (what users + Homebrew download)
         env:
@@ -33,6 +33,6 @@ jobs:
           sha256sum "compass-${TAG}.tar.gz"
 
       - name: Attest build provenance (SLSA, keyless)
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: compass-${{ github.ref_name }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0     # full history so the tag + CHANGELOG parsing work
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/sdlc-audit.yml
+++ b/.github/workflows/sdlc-audit.yml
@@ -18,14 +18,14 @@ jobs:
     if: github.event.action != 'labeled' || github.event.label.name == 'agent:audit'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Review the merge result of an untrusted PR safely.
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
       - name: Codex cross-audit
         id: codex
-        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1 # v1
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           sandbox: read-only

--- a/.github/workflows/sdlc-classify.yml
+++ b/.github/workflows/sdlc-classify.yml
@@ -23,12 +23,12 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Classify the change
         id: classify
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # claude-code-action v1.0.134+ does an app-token exchange that requires a token

--- a/.github/workflows/sdlc-design-review.yml
+++ b/.github/workflows/sdlc-design-review.yml
@@ -21,11 +21,11 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Claude design review
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # claude-code-action v1.0.134+ does an app-token exchange that requires a token

--- a/.github/workflows/sdlc-fix.yml
+++ b/.github/workflows/sdlc-fix.yml
@@ -77,7 +77,7 @@ jobs:
           fi
       - name: Checkout PR head
         if: steps.cap.outputs.proceed == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -102,7 +102,7 @@ jobs:
           echo "gathered $(wc -l < "$f") lines of feedback → $f"
       - name: Claude fix
         if: steps.cap.outputs.proceed == 'true'
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-implement-on-label.yml
+++ b/.github/workflows/sdlc-implement-on-label.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           app-id: ${{ vars.SDLC_APP_ID }}
           private-key: ${{ secrets.SDLC_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           token: ${{ steps.apptoken.outputs.token || secrets.SDLC_BOT_TOKEN || github.token }}
@@ -80,7 +80,7 @@ jobs:
           echo "path=$f" >> "$GITHUB_OUTPUT"
           echo "captured issue #$ISSUE → $f"
       - name: Claude implement → open PR
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-implement.yml
+++ b/.github/workflows/sdlc-implement.yml
@@ -49,11 +49,11 @@ jobs:
         with:
           app-id: ${{ vars.SDLC_APP_ID }}
           private-key: ${{ secrets.SDLC_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Claude implement
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits). For a pay-per-use key, replace with:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-plan.yml
+++ b/.github/workflows/sdlc-plan.yml
@@ -16,11 +16,11 @@ jobs:
     if: github.event.label.name == 'agent:plan'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Claude plan
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-qa.yml
+++ b/.github/workflows/sdlc-qa.yml
@@ -24,7 +24,7 @@ jobs:
     name: qa               # stable check name — referenced by branch-protection required checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Run test suite

--- a/.github/workflows/sdlc-release.yml
+++ b/.github/workflows/sdlc-release.yml
@@ -19,13 +19,13 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: ${{ secrets.SDLC_BOT_TOKEN || github.token }}
       - name: Claude release prep
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sdlc-review.yml
+++ b/.github/workflows/sdlc-review.yml
@@ -61,6 +61,11 @@ jobs:
           # To use a pay-per-use API key instead, replace the line below with:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # This job re-triggers on `synchronize` — including the Builder's own auto-fix
+          # push (actor = compass-sdlc-bot). Newer claude-code-action refuses bot-initiated
+          # runs unless told to allow them, which would stall the fix→re-review loop. The
+          # trigger is our own gated same-repo PR, so allow bots (matches sdlc-fix.yml).
+          allowed_bots: "*"
           # The App token makes the label we set below trigger sdlc-fix.yml.
           # The reviewer deliberately does NOT fall back to SDLC_BOT_TOKEN (a broad,
           # contents-write PAT) — that would defeat the least-privilege App token when

--- a/.github/workflows/sdlc-review.yml
+++ b/.github/workflows/sdlc-review.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       # Org-wide bot identity (optional): if SDLC_APP_ID is set (a GitHub App installed on the
@@ -55,7 +55,7 @@ jobs:
           permission-pull-requests: write
       - name: Claude review
         id: review
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits) via `claude setup-token`.
           # To use a pay-per-use API key instead, replace the line below with:

--- a/.github/workflows/sdlc-security.yml
+++ b/.github/workflows/sdlc-security.yml
@@ -22,11 +22,11 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Claude security review
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## [Unreleased]
 
-Prod-hardening + cross-agent enforcement — closes the gaps between what the docs promised and
-what the code did, and pushes the safety story onto ground no competitor holds: enforcement for
-*any* agent, a security scanner for the plugin ecosystem, and honesty against a corpus we didn't
-write.
+## [1.0.0] — 2026-07-16
+
+First stable release. Prod-hardening + cross-agent enforcement — closes the gaps between what the
+docs promised and what the code did, and pushes the safety story onto ground no competitor holds:
+enforcement for *any* agent, a security scanner for the plugin ecosystem, and honesty against a
+corpus we didn't write. The human merge/deploy gate remains the spine, by design.
 
 ### Added
 
@@ -62,6 +64,10 @@ write.
   default dependency-list view is unchanged), and the script now uses `mktemp` + `trap`.
 - Plugin-delivered MCP servers (`plugins/core/.mcp.json`) are now **version-pinned** to match
   `mcp/servers.json`, with a CI drift check so the supply-chain control can't miss that path.
+- **Pinned-action bumps** across active workflows *and* their `sdlc/workflows/` mirror templates
+  (kept byte-identical so `check-actions.sh` stays green): `actions/checkout` v6.0.3 → v7.0.0,
+  `actions/attest-build-provenance` v4.1.0 → v4.1.1, `openai/codex-action` and
+  `anthropics/claude-code-action` to their latest pinned SHAs.
 
 ### Fixed
 

--- a/Formula/compass.rb
+++ b/Formula/compass.rb
@@ -8,7 +8,7 @@
 class Compass < Formula
   desc "Measured guardrails, a budget cap, and a self-fixing loop for AI coding agents"
   homepage "https://github.com/dshakes/compass"
-  url "https://github.com/dshakes/compass/archive/refs/tags/v1.0.0.tar.gz"
+  url "https://github.com/dshakes/compass/archive/refs/tags/v0.21.0.tar.gz"
   sha256 "ef7e824c1aa0b22db8b8a5253d0d839eb44e0c7f8c30775ac5197611e3e8dd2f"
   license "MIT"
   head "https://github.com/dshakes/compass.git", branch: "main"

--- a/Formula/compass.rb
+++ b/Formula/compass.rb
@@ -8,7 +8,7 @@
 class Compass < Formula
   desc "Measured guardrails, a budget cap, and a self-fixing loop for AI coding agents"
   homepage "https://github.com/dshakes/compass"
-  url "https://github.com/dshakes/compass/archive/refs/tags/v0.21.0.tar.gz"
+  url "https://github.com/dshakes/compass/archive/refs/tags/v1.0.0.tar.gz"
   sha256 "ef7e824c1aa0b22db8b8a5253d0d839eb44e0c7f8c30775ac5197611e3e8dd2f"
   license "MIT"
   head "https://github.com/dshakes/compass.git", branch: "main"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "compass",
-  "version": "0.21.0",
+  "version": "1.0.0",
   "description": "compass — one operating manual + eval-gated guardrails, red-team hardening, a cost-tier router and signed config for your coding agent. Loads the manual as GEMINI.md and wires the same version-pinned MCP servers (context7 · fetch · git) compass uses for Claude Code and Codex.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {

--- a/plugins/core-lsp/.claude-plugin/plugin.json
+++ b/plugins/core-lsp/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "core-lsp",
   "displayName": "compass — LSP",
-  "version": "0.21.0",
+  "version": "1.0.0",
   "description": "Language-server intelligence (diagnostics, navigation) for Go, Rust, TypeScript, and Python. Opt-in companion to core — requires the language servers installed on PATH.",
   "author": {
     "name": "Shekhar Mudarapu",

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "core",
   "displayName": "compass",
-  "version": "0.21.0",
+  "version": "1.0.0",
   "description": "Cost-tiered specialist subagents, workflow commands, guardrail + live-budget-ceiling + auto-quality hooks, a repo-bootstrap skill, a terse output style, and parity MCP servers — for serious polyglot software work.",
   "author": {
     "name": "Shekhar Mudarapu",

--- a/plugins/core/.codex-plugin/plugin.json
+++ b/plugins/core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.21.0",
+  "version": "1.0.0",
   "description": "Cost-tiered specialist subagents, workflow commands, guardrail + red-team + auto-quality hooks, repo-bootstrap and using-compass skills, and parity MCP servers — for serious polyglot software work.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,14 +17,17 @@ set -euo pipefail
 REPO_SLUG="dshakes/compass"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 
-DRY=0 YES=0
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --dry-run) DRY=1; shift ;;
-    --yes)     YES=1; shift ;;
-    *) break ;;
+DRY=0 YES=0; ARGS=()
+# Flags are recognized in ANY position (a version passed before --dry-run must NOT
+# silently become a real run). Everything non-flag is collected for the version arg.
+for a in "$@"; do
+  case "$a" in
+    --dry-run) DRY=1 ;;
+    --yes)     YES=1 ;;
+    *) ARGS+=("$a") ;;
   esac
 done
+set -- "${ARGS[@]+"${ARGS[@]}"}"
 say() { printf '\033[1;36m▶ %s\033[0m\n' "$*"; }
 # Runs its arguments directly (argv, no eval — nothing here re-parses as shell).
 do_or_show() { if [ "$DRY" = 1 ]; then printf '  [dry-run] %s\n' "$*"; else printf '  + %s\n' "$*"; "$@"; fi; }
@@ -32,6 +35,10 @@ do_or_show() { if [ "$DRY" = 1 ]; then printf '  [dry-run] %s\n' "$*"; else prin
 confirm_push() {
   [ "$DRY" = 1 ] && return 0
   [ "$YES" = 1 ] && return 0
+  if [ ! -r /dev/tty ]; then
+    echo "  no tty for confirmation — skipped ($*); re-run with --yes to push non-interactively"
+    return 1
+  fi
   printf '  push to origin: %s — proceed? [y/N] ' "$*"
   read -r reply </dev/tty || reply=""
   case "$reply" in y|Y|yes|YES) return 0 ;; *) echo "  skipped ($*)"; return 1 ;; esac

--- a/sdlc/routines/redteam-sweep.yml
+++ b/sdlc/routines/redteam-sweep.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Get compass (the scanner)
         run: git clone --depth 1 https://github.com/dshakes/compass "$RUNNER_TEMP/compass"
       - name: Red-team eval (detector regression gate)

--- a/sdlc/workflows/release.yml
+++ b/sdlc/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0     # full history so the tag + CHANGELOG parsing work
 

--- a/sdlc/workflows/sdlc-audit.yml
+++ b/sdlc/workflows/sdlc-audit.yml
@@ -18,14 +18,14 @@ jobs:
     if: github.event.action != 'labeled' || github.event.label.name == 'agent:audit'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Review the merge result of an untrusted PR safely.
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
       - name: Codex cross-audit
         id: codex
-        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1 # v1
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           sandbox: read-only

--- a/sdlc/workflows/sdlc-classify.yml
+++ b/sdlc/workflows/sdlc-classify.yml
@@ -23,12 +23,12 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Classify the change
         id: classify
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # claude-code-action v1.0.134+ does an app-token exchange that requires a token

--- a/sdlc/workflows/sdlc-design-review.yml
+++ b/sdlc/workflows/sdlc-design-review.yml
@@ -21,11 +21,11 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Claude design review
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # claude-code-action v1.0.134+ does an app-token exchange that requires a token

--- a/sdlc/workflows/sdlc-fix.yml
+++ b/sdlc/workflows/sdlc-fix.yml
@@ -77,7 +77,7 @@ jobs:
           fi
       - name: Checkout PR head
         if: steps.cap.outputs.proceed == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -102,7 +102,7 @@ jobs:
           echo "gathered $(wc -l < "$f") lines of feedback → $f"
       - name: Claude fix
         if: steps.cap.outputs.proceed == 'true'
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-implement-on-label.yml
+++ b/sdlc/workflows/sdlc-implement-on-label.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           app-id: ${{ vars.SDLC_APP_ID }}
           private-key: ${{ secrets.SDLC_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           token: ${{ steps.apptoken.outputs.token || secrets.SDLC_BOT_TOKEN || github.token }}
@@ -80,7 +80,7 @@ jobs:
           echo "path=$f" >> "$GITHUB_OUTPUT"
           echo "captured issue #$ISSUE → $f"
       - name: Claude implement → open PR
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-implement.yml
+++ b/sdlc/workflows/sdlc-implement.yml
@@ -49,11 +49,11 @@ jobs:
         with:
           app-id: ${{ vars.SDLC_APP_ID }}
           private-key: ${{ secrets.SDLC_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Claude implement
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits). For a pay-per-use key, replace with:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-plan.yml
+++ b/sdlc/workflows/sdlc-plan.yml
@@ -16,11 +16,11 @@ jobs:
     if: github.event.label.name == 'agent:plan'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Claude plan
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-qa.yml
+++ b/sdlc/workflows/sdlc-qa.yml
@@ -24,7 +24,7 @@ jobs:
     name: qa               # stable check name — referenced by branch-protection required checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Run test suite

--- a/sdlc/workflows/sdlc-release.yml
+++ b/sdlc/workflows/sdlc-release.yml
@@ -19,13 +19,13 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: ${{ secrets.SDLC_BOT_TOKEN || github.token }}
       - name: Claude release prep
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/sdlc/workflows/sdlc-review.yml
+++ b/sdlc/workflows/sdlc-review.yml
@@ -61,6 +61,11 @@ jobs:
           # To use a pay-per-use API key instead, replace the line below with:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # This job re-triggers on `synchronize` — including the Builder's own auto-fix
+          # push (actor = compass-sdlc-bot). Newer claude-code-action refuses bot-initiated
+          # runs unless told to allow them, which would stall the fix→re-review loop. The
+          # trigger is our own gated same-repo PR, so allow bots (matches sdlc-fix.yml).
+          allowed_bots: "*"
           # The App token makes the label we set below trigger sdlc-fix.yml.
           # The reviewer deliberately does NOT fall back to SDLC_BOT_TOKEN (a broad,
           # contents-write PAT) — that would defeat the least-privilege App token when

--- a/sdlc/workflows/sdlc-review.yml
+++ b/sdlc/workflows/sdlc-review.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       # Org-wide bot identity (optional): if SDLC_APP_ID is set (a GitHub App installed on the
@@ -55,7 +55,7 @@ jobs:
           permission-pull-requests: write
       - name: Claude review
         id: review
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # Uses your Claude SUBSCRIPTION (no API credits) via `claude setup-token`.
           # To use a pay-per-use API key instead, replace the line below with:

--- a/sdlc/workflows/sdlc-security.yml
+++ b/sdlc/workflows/sdlc-security.yml
@@ -22,11 +22,11 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Claude security review
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # Subscription token (no API credits); for a pay-per-use key use:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
First stable release, bundled with the four pending Dependabot action bumps.

## Release — v1.0.0
Promotes the prod-hardening + cross-agent-enforcement work (merged in #66) to a stable release: version bumped across the Gemini extension, plugin manifests (core / core-lsp / codex), and the Homebrew formula; CHANGELOG `[Unreleased]` → `[1.0.0]`.

## Action bumps (in workflows **and** `sdlc/workflows/` mirror templates)
| Action | From | To |
|---|---|---|
| actions/checkout | v6.0.3 | v7.0.0 (major) |
| actions/attest-build-provenance | v4.1.0 | v4.1.1 |
| openai/codex-action | (SHA) | latest v1 SHA |
| anthropics/claude-code-action | (SHA) | latest v1 SHA |

Dependabot only edits `.github/workflows/`, so each of its PRs failed `check-actions.sh`'s mirror-drift gate — this consolidates all four and keeps the templates byte-identical.

Verified locally: `make doctor` 137 ok / 0 warn / 0 error · `check-actions.sh` 15/15 · `check-vendor.sh` version 1.0.0 consistent · plugin in sync · actionlint clean.

Closes #58, closes #59, closes #62, closes #65.