### PR TITLE
fix(sdlc): skip agent jobs on Dependabot-actor runs (no secrets)

### DIFF
--- a/.github/workflows/sdlc-audit.yml
+++ b/.github/workflows/sdlc-audit.yml
@@ -15,7 +15,8 @@ permissions:
 jobs:
   audit:
     # Auto on open/reopen, or on the agent:audit label. (label.name is null on open events.)
-    if: github.event.action != 'labeled' || github.event.label.name == 'agent:audit'
+    # dependabot-actor runs get Dependabot's (empty) secret store — agent can't auth, so skip
+    if: github.actor != 'dependabot[bot]' && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/sdlc-classify.yml
+++ b/.github/workflows/sdlc-classify.yml
@@ -20,7 +20,8 @@ concurrency:
 
 jobs:
   classify:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # dependabot-actor runs get Dependabot's (empty) secret store — agent can't auth, so skip
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/sdlc-review.yml
+++ b/.github/workflows/sdlc-review.yml
@@ -25,7 +25,8 @@ jobs:
     name: review # stable check name — referenced by branch-protection required checks
     # Same-repo PRs only: secrets (and the loop) aren't available to forks; forks get a
     # read-only review on a best-effort basis but never the write-capable fix loop.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # dependabot-actor runs get Dependabot's (empty) secret store — agent can't auth, so skip
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/sdlc-security.yml
+++ b/.github/workflows/sdlc-security.yml
@@ -19,7 +19,8 @@ concurrency:
 
 jobs:
   security:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # dependabot-actor runs get Dependabot's (empty) secret store — agent can't auth, so skip
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/sdlc/workflows/sdlc-audit.yml
+++ b/sdlc/workflows/sdlc-audit.yml
@@ -15,7 +15,8 @@ permissions:
 jobs:
   audit:
     # Auto on open/reopen, or on the agent:audit label. (label.name is null on open events.)
-    if: github.event.action != 'labeled' || github.event.label.name == 'agent:audit'
+    # dependabot-actor runs get Dependabot's (empty) secret store — agent can't auth, so skip
+    if: github.actor != 'dependabot[bot]' && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/sdlc/workflows/sdlc-classify.yml
+++ b/sdlc/workflows/sdlc-classify.yml
@@ -20,7 +20,8 @@ concurrency:
 
 jobs:
   classify:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # dependabot-actor runs get Dependabot's (empty) secret store — agent can't auth, so skip
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/sdlc/workflows/sdlc-review.yml
+++ b/sdlc/workflows/sdlc-review.yml
@@ -25,7 +25,8 @@ jobs:
     name: review # stable check name — referenced by branch-protection required checks
     # Same-repo PRs only: secrets (and the loop) aren't available to forks; forks get a
     # read-only review on a best-effort basis but never the write-capable fix loop.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # dependabot-actor runs get Dependabot's (empty) secret store — agent can't auth, so skip
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/sdlc/workflows/sdlc-security.yml
+++ b/sdlc/workflows/sdlc-security.yml
@@ -19,7 +19,8 @@ concurrency:
 
 jobs:
   security:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # dependabot-actor runs get Dependabot's (empty) secret store — agent can't auth, so skip
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Why
Every Dependabot PR showed 4 red agent checks (classify/review/security/audit) because Dependabot-triggered workflow runs get Dependabot's secret store — the agent tokens are empty, so the actions fail before doing anything.

## What
- Add `github.actor != 'dependabot[bot]'` to the 4 agent jobs' `if:` (templates + dogfood mirrors, byte-identical per check-actions.sh).
- Human pushes to a Dependabot branch still run the agents with real secrets (observed on #71/#72 re-runs).

## Verification
- `scripts/check-actions.sh`: 16 passed, 0 failed (mirror drift, pinning, injection, least-privilege)
- `actionlint`: clean