### PR TITLE
fix+feat(audit): close the 2026-06 audit's open gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Guardrail bypass corpus (protect-paths policy eval)
         run: bash scripts/test-protect-paths.sh
 
+      - name: Hook behavior corpus (format-on-edit · checkpoint-wip · inject-context)
+        run: bash scripts/test-hooks.sh
+
       - name: Budget ceiling (live spend hard-gate eval — session + daily)
         run: bash scripts/test-budget-gate.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project are documented here. Format loosely follows
 
 ### Added
 
+- **`SDLC_BUDGET` is now a hard ceiling** — the orchestrator halts the run (exit 3) once
+  cumulative spend reaches the total, and each step's cap is min(per-step, remaining), so the
+  last step can't overshoot. Was a per-step-only "hint". Selftest-mirrored with source anchors.
+- **Hook behavior corpus** — `scripts/test-hooks.sh`: 84 hermetic assertions covering
+  `format-on-edit`, `checkpoint-wip`, `inject-context` (the three previously-untested hooks),
+  mutation-tested, wired into `doctor` and CI.
 - **`pr-shepherd` skill** — take every open PR end-to-end: diagnose red checks from the
   actual logs, classify (real defect / mechanical / environmental), fix mechanical failures
   on the PR branch (verified locally before pushing, three-strikes cap), and stop at the

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Every AI-agent config claims "safe" and "cheap." compass is the one that hands y
 **🛡 Guardrails with a score.** Catastrophic commands and secret writes are blocked *before they run* — and the policy is eval-gated in CI, not asserted.
 
 ```bash
-compass bench     # → guardrail 100% precision/recall (61-case corpus), router 96.9% — in CI
+compass bench     # → guardrail 100% precision/recall (61-case bench corpus; a separate 147-case bypass corpus gates CI), router 96.9%
 # then ask the agent to `rm -rf /` or write a .env → denied; `rm -rf ./build` → allowed
 ```
 

--- a/claude/hooks/lib/policy.sh
+++ b/claude/hooks/lib/policy.sh
@@ -103,7 +103,7 @@ secret_file_reason() {
   local file="$1" base; base="$(basename "$file")"
   case "$base" in
     .env|.env.*|.envrc|*.pem|*.key|id_rsa|id_dsa|id_ecdsa|id_ed25519|*.p12|*.pfx|*.keystore|*.jks|\
-credentials|credentials.*|.npmrc|.pypirc|.netrc|_netrc|.htpasswd|secrets.yaml|secrets.yml|secrets.json|.dockercfg)
+credentials|credentials.*|.npmrc|.pypirc|.netrc|_netrc|.htpasswd|secrets.yaml|secrets.yml|secrets.json|.dockercfg|application.properties|application-*.properties)
       printf "Refusing to write secret-bearing file '%s'. If this is intentional, edit it yourself or use 'ask' permission." "$base"; return 0 ;;
   esac
   case "$file" in

--- a/docs/15-competitive-audit.md
+++ b/docs/15-competitive-audit.md
@@ -371,3 +371,34 @@ native-install** (per-vendor manifests from one source — see the Gemini extens
 **trigger-first, enforceable `SKILL.md`** style (red-flags / verification checklists — see
 `verification-before-completion`, `systematic-debugging`). What compass deliberately does **not**
 try to be: a methodology framework — it leads with measured safety + provenance instead.
+
+---
+
+## 2026-07 refresh — field check without the name-dropping
+
+A fresh sweep of the five most-adopted neighbouring projects (verified via the GitHub API,
+2026-07-25; categories, not names — the ecosystem churns and renames faster than a doc should):
+
+**What became table stakes across the field** — multi-harness support, one-line install,
+plugin-marketplace listing, a docs domain, a large subagent roster, tiered model routing,
+spec-before-code workflows, a community channel. compass covers the capability half of this
+list; the *distribution* half (marketplace presence beyond the manifest, install ergonomics,
+visual discovery) is the actual gap.
+
+**Where compass still leads, verified thin-field** — agent review/security/QA gates as real
+CI jobs on PRs (nearest neighbour has a partial verification pipeline; another outsources
+review to a SaaS), release provenance / SLSA attestation (~one partial peer), and a
+red-team layer with effectively one peer. Component-level *eval gating* now has two credible
+peers (one certifies its catalog with static + LLM-judge + Monte-Carlo layers; one evals
+whether its skills actually fire) — compass's edge is that its evals gate CI, not a catalog.
+
+**Frontier moves observed elsewhere, worth watching** — persistent cross-session vector
+memory with trajectory learning; hosted zero-install demos; live agent dashboards with
+kill switches; opt-out adoption telemetry (exactly one project runs it — and it is the only
+one that knows its real adoption instead of guessing from stars).
+
+**Closed this cycle (from the 2026-06 gap list)** — Dependabot-actor agent-job skip,
+Spring `application.properties` in the secret blocklist (+ corpus cases), the 61-vs-147
+corpus-count clarity, `pr-shepherd` (PR handoff→merge-gate loop), and `SDLC_BUDGET`
+promoted from hint to enforced cumulative ceiling (halt + min(step, remaining) cap,
+selftest-mirrored).

--- a/docs/16-hardening-and-frontier.md
+++ b/docs/16-hardening-and-frontier.md
@@ -65,7 +65,8 @@ contract. Every bypass the audit found is closed:
 | `git push origin +main` (plus-refspec), `git -c k=v push --force` | blocked |
 
 This is **"policy-as-code with an eval"**: [`scripts/test-protect-paths.sh`](../scripts/test-protect-paths.sh)
-is a 61-case labeled corpus (must-block / must-allow) — the highest-stakes file finally
+is a 147-case labeled corpus (must-block / must-allow; distinct from the 61-case
+`compass bench` corpus) — the highest-stakes file finally
 has a test, and it found 3 real bugs while being written. Still footgun-prevention, **not
 a security boundary** — unchanged framing.
 

--- a/plugins/core/hooks/lib/policy.sh
+++ b/plugins/core/hooks/lib/policy.sh
@@ -103,7 +103,7 @@ secret_file_reason() {
   local file="$1" base; base="$(basename "$file")"
   case "$base" in
     .env|.env.*|.envrc|*.pem|*.key|id_rsa|id_dsa|id_ecdsa|id_ed25519|*.p12|*.pfx|*.keystore|*.jks|\
-credentials|credentials.*|.npmrc|.pypirc|.netrc|_netrc|.htpasswd|secrets.yaml|secrets.yml|secrets.json|.dockercfg)
+credentials|credentials.*|.npmrc|.pypirc|.netrc|_netrc|.htpasswd|secrets.yaml|secrets.yml|secrets.json|.dockercfg|application.properties|application-*.properties)
       printf "Refusing to write secret-bearing file '%s'. If this is intentional, edit it yourself or use 'ask' permission." "$base"; return 0 ;;
   esac
   case "$file" in

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -76,6 +76,10 @@ else fail "vendor manifest drift — run: scripts/check-vendor.sh"; fi
 if "$REPO"/scripts/test-protect-paths.sh >/dev/null 2>&1; then pass "guardrail bypass corpus passes (protect-paths policy)"
 else fail "guardrail corpus failed — run: scripts/test-protect-paths.sh"; fi
 
+# Hook behavior: format-on-edit / checkpoint-wip / inject-context must stay non-destructive.
+if "$REPO"/scripts/test-hooks.sh >/dev/null 2>&1; then pass "hook behavior corpus passes (format · checkpoint · context)"
+else fail "hook behavior corpus failed — run: scripts/test-hooks.sh"; fi
+
 # Red-team policy: the prompt-injection / config-override / malware / insecure-code eval.
 if "$REPO"/scripts/test-redteam.sh >/dev/null 2>&1; then pass "red-team corpus passes (injection · override · malware · insecure-code)"
 else fail "red-team corpus failed — run: scripts/test-redteam.sh"; fi

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# test-hooks.sh — behavior tests for the three non-guardrail hooks that run on the hot
+# path of every session: format-on-edit.sh (PostToolUse formatter), checkpoint-wip.sh
+# (Stop snapshot), inject-context.sh (SessionStart primer).
+#
+# What these hooks must never do is the point of the corpus: mangle a file they don't
+# own (JSONC), touch the working tree, or break a turn when a formatter is missing or
+# broken. Every "silent, best-effort" claim in their headers is pinned here.
+#
+# Hermetic: temp git repos + stub formatters on a shadowing PATH, so no real gofmt /
+# biome / ruff is required and the result is the same on every machine. No network.
+# Runs in CI. Mirrors the style of scripts/test-protect-paths.sh.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FMT="$ROOT/claude/hooks/format-on-edit.sh"
+WIP="$ROOT/claude/hooks/checkpoint-wip.sh"
+CTX="$ROOT/claude/hooks/inject-context.sh"
+
+pass=0; fail=0
+ok() { printf '  \033[32mok\033[0m   %s\n' "$1"; pass=$((pass + 1)); }
+no() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; fail=$((fail + 1)); }
+eq()    { if [ "$2" = "$3" ]; then ok "$1"; else no "$1 (got '$2', want '$3')"; fi; }
+has()   { case "$2" in *"$3"*) ok "$1" ;; *) no "$1 (missing '$3')" ;; esac; }
+lacks() { case "$2" in *"$3"*) no "$1 (unexpectedly contains '$3')" ;; *) ok "$1" ;; esac; }
+
+command -v git >/dev/null 2>&1 || { echo "git required for hook tests" >&2; exit 1; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/compass-hooks.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+# ---------------------------------------------------------------- fixtures ----
+# Stub formatters: each appends a marker to any file argument, so "did the hook run
+# the formatter?" is observable without installing gofmt/biome/ruff/shfmt.
+STUB="$TMP/stub"; mkdir -p "$STUB"
+mkstub() {
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'for a in "$@"; do [ -f "$a" ] && printf "FORMATTED\n" >> "$a"; done' \
+    'exit 0' > "$STUB/$1"
+  chmod +x "$STUB/$1"
+}
+for t in gofmt goimports biome prettier ruff black shfmt terraform buf; do mkstub "$t"; done
+# A formatter that is installed but fails — the hook must still exit 0 and leave the file alone.
+printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$STUB/rustfmt"; chmod +x "$STUB/rustfmt"
+
+# A PATH with the hook's own dependencies but NO formatter of any kind, so
+# `have <formatter>` is deterministically false rather than machine-dependent.
+MIN="$TMP/minbin"; mkdir -p "$MIN"
+for t in bash sh cat grep sed awk jq python3 date mkdir basename dirname git env; do
+  p="$(command -v "$t" 2>/dev/null)" && ln -sf "$p" "$MIN/$t"
+done
+
+MET="$TMP/metrics"   # COMPASS_HOME for the hooks, so nothing lands in ~/.compass
+
+# run_fmt <path-to-run-hook-with> [PATH-override] — feeds hook-shaped JSON on stdin.
+# Always runs from $TMP so a stray metric/git lookup can never touch the real repo.
+run_fmt() {
+  local path="$1" pathenv="${2:-$STUB:$PATH}" json
+  json="$(printf '{"tool_name":"Edit","tool_input":{"file_path":"%s"}}' "$path")"
+  RC=0
+  printf '%s' "$json" | ( cd "$TMP" && PATH="$pathenv" COMPASS_HOME="$MET" bash "$FMT" ) >/dev/null 2>&1 || RC=$?
+}
+# formatted <label> <file> — the stub marker landed (the hook did format it).
+formatted()   { if grep -q FORMATTED "$2" 2>/dev/null; then ok "$1"; else no "$1 (not formatted)"; fi; }
+untouched()   { if grep -q FORMATTED "$2" 2>/dev/null; then no "$1 (was formatted, should not be)"; else ok "$1"; fi; }
+mkfile()      { printf '%s\n' "${2:-x}" > "$TMP/$1"; printf '%s' "$TMP/$1"; }
+
+echo "format-on-edit — formats the file types it claims to, with the canonical tool:"
+for f in a.go a.ts a.tsx a.js a.json a.css a.md a.yaml a.py a.sh a.tf a.proto; do
+  p="$(mkfile "$f")"; run_fmt "$p"
+  eq "exit 0 for $f" "$RC" 0
+  formatted "formatted $f" "$p"
+done
+
+echo "format-on-edit — JSONC guard: comment-bearing JSON is NEVER reformatted:"
+for f in tsconfig.json tsconfig.build.json settings.jsonc; do
+  p="$(mkfile "$f" '{ // a comment biome would strip
+  "a": 1 }')"
+  run_fmt "$p"
+  eq "exit 0 for $f" "$RC" 0
+  untouched "left $f alone" "$p"
+done
+mkdir -p "$TMP/.vscode"; p="$TMP/.vscode/settings.json"; printf '{ // comment\n}\n' > "$p"
+run_fmt "$p"; untouched "left .vscode/settings.json alone" "$p"
+
+echo "format-on-edit — unsupported / unknown extensions are left alone:"
+for f in a.txt a.rb a.bin Dockerfile; do
+  p="$(mkfile "$f")"; run_fmt "$p"
+  eq "exit 0 for $f" "$RC" 0
+  untouched "left $f alone" "$p"
+done
+
+echo "format-on-edit — degrades quietly (a turn must never fail on a missing tool):"
+p="$(mkfile "nofmt.sh")"; before="$(cat "$p")"
+run_fmt "$p" "$MIN"
+eq  "exit 0 with no formatter installed" "$RC" 0
+eq  "file unchanged with no formatter installed" "$(cat "$p")" "$before"
+p="$(mkfile "broken.rs")"; before="$(cat "$p")"
+run_fmt "$p"
+eq  "exit 0 when the formatter itself fails" "$RC" 0
+eq  "file unchanged when the formatter fails" "$(cat "$p")" "$before"
+run_fmt "$TMP/does-not-exist.go";  eq "exit 0 for a nonexistent file"  "$RC" 0
+RC=0; printf '{"tool_name":"Bash","tool_input":{"command":"ls"}}' | \
+  ( cd "$TMP" && PATH="$STUB:$PATH" COMPASS_HOME="$MET" bash "$FMT" ) >/dev/null 2>&1 || RC=$?
+eq "exit 0 when there is no file_path at all" "$RC" 0
+RC=0; printf 'not json at all' | \
+  ( cd "$TMP" && PATH="$STUB:$PATH" COMPASS_HOME="$MET" bash "$FMT" ) >/dev/null 2>&1 || RC=$?
+eq "exit 0 on malformed stdin" "$RC" 0
+
+echo "format-on-edit — logs the impact metric only when it actually formatted:"
+has "metric recorded for a formatted file" "$(cat "$MET/metrics.tsv" 2>/dev/null)" "format"
+M2="$TMP/metrics2"; RC=0
+printf '{"tool_input":{"file_path":"%s"}}' "$(mkfile skip.txt)" | \
+  ( cd "$TMP" && PATH="$STUB:$PATH" COMPASS_HOME="$M2" bash "$FMT" ) >/dev/null 2>&1 || RC=$?
+lacks "no metric when nothing was formatted" "$(cat "$M2/metrics.tsv" 2>/dev/null)" "format"
+
+# ------------------------------------------------------------ checkpoint-wip ----
+newrepo() { # <dir> — a repo with one commit; echoes the dir
+  local g="$1"
+  git init -q "$g"
+  git -C "$g" config user.email t@t; git -C "$g" config user.name t
+  printf 'one\n' > "$g/a.txt"
+  git -C "$g" add a.txt
+  git -C "$g" commit -qm c1
+  printf '%s' "$g"
+}
+run_wip() { # <cwd-json-value> — runs the Stop hook; always from a safe cwd
+  RC=0
+  printf '{"cwd":"%s"}' "$1" | ( cd "$TMP" && bash "$WIP" ) >/dev/null 2>&1 || RC=$?
+}
+
+echo "checkpoint-wip — snapshots dirty work to refs/compass/wip/<branch>:"
+G="$(newrepo "$TMP/wip1")"
+BR="$(git -C "$G" rev-parse --abbrev-ref HEAD)"
+printf 'one\nTWO-uncommitted\n' > "$G/a.txt"
+STATUS_BEFORE="$(git -C "$G" status --porcelain)"; HEAD_BEFORE="$(git -C "$G" rev-parse HEAD)"
+run_wip "$G"
+eq  "exit 0"                     "$RC" 0
+if git -C "$G" show-ref --verify --quiet "refs/compass/wip/$BR"; then ok "created refs/compass/wip/$BR"
+else no "did not create refs/compass/wip/$BR"; fi
+# The promise is a RESTORABLE snapshot, not just a ref that exists.
+eq  "snapshot holds the uncommitted content" \
+    "$(git -C "$G" show "refs/compass/wip/$BR:a.txt" 2>/dev/null)" "$(printf 'one\nTWO-uncommitted')"
+echo "checkpoint-wip — never destroys working-tree state:"
+eq  "working tree content preserved" "$(cat "$G/a.txt")" "$(printf 'one\nTWO-uncommitted\n')"
+eq  "git status unchanged"           "$(git -C "$G" status --porcelain)" "$STATUS_BEFORE"
+eq  "HEAD unchanged"                 "$(git -C "$G" rev-parse HEAD)" "$HEAD_BEFORE"
+eq  "branch history untouched"       "$(git -C "$G" rev-list --count HEAD)" 1
+eq  "stash list untouched"           "$(git -C "$G" stash list | wc -l | tr -d ' ')" 0
+
+echo "checkpoint-wip — staged changes are snapshotted too:"
+G2="$(newrepo "$TMP/wip2")"; BR2="$(git -C "$G2" rev-parse --abbrev-ref HEAD)"
+printf 'staged\n' > "$G2/a.txt"; git -C "$G2" add a.txt
+run_wip "$G2"
+eq "exit 0" "$RC" 0
+if git -C "$G2" show-ref --verify --quiet "refs/compass/wip/$BR2"; then ok "snapshotted a staged-only change"
+else no "staged-only change was not snapshotted"; fi
+eq "index still staged" "$(git -C "$G2" diff --cached --name-only)" "a.txt"
+
+echo "checkpoint-wip — no-ops it must not turn into work:"
+G3="$(newrepo "$TMP/wip3")"; BR3="$(git -C "$G3" rev-parse --abbrev-ref HEAD)"
+run_wip "$G3"
+eq "exit 0 on a clean tree" "$RC" 0
+if git -C "$G3" show-ref --verify --quiet "refs/compass/wip/$BR3"; then no "created a ref for a clean tree"
+else ok "no ref created for a clean tree"; fi
+# Untracked-only: `git stash create` cannot capture it, so the documented behaviour is
+# "no snapshot" — pinned here so the limitation is visible instead of assumed.
+printf 'new\n' > "$G3/untracked.txt"
+run_wip "$G3"
+eq "exit 0 with only untracked files" "$RC" 0
+if [ -f "$G3/untracked.txt" ]; then ok "untracked file left in place"; else no "untracked file disappeared"; fi
+run_wip "$TMP/not-a-repo-$$"
+eq "exit 0 when cwd does not exist" "$RC" 0
+NOGIT="$TMP/plain"; mkdir -p "$NOGIT"; printf 'x\n' > "$NOGIT/f.txt"
+run_wip "$NOGIT"
+eq "exit 0 outside a git repo" "$RC" 0
+RC=0; printf '{}' | ( cd "$NOGIT" && bash "$WIP" ) >/dev/null 2>&1 || RC=$?
+eq "exit 0 with no cwd field (falls back to \$PWD)" "$RC" 0
+
+echo "checkpoint-wip — detached HEAD and slashed branch names do not break it:"
+G4="$(newrepo "$TMP/wip4")"
+git -C "$G4" checkout -q -b feature/deep/name
+printf 'dirty\n' > "$G4/a.txt"
+run_wip "$G4"
+eq "exit 0 on a slashed branch" "$RC" 0
+if git -C "$G4" show-ref --verify --quiet 'refs/compass/wip/feature/deep/name'; then ok "ref path handles slashed branch"
+else no "slashed branch produced no ref"; fi
+git -C "$G4" checkout -q --detach
+printf 'dirtier\n' > "$G4/a.txt"
+run_wip "$G4"
+eq "exit 0 on detached HEAD" "$RC" 0
+eq "working tree survives detached HEAD run" "$(cat "$G4/a.txt")" "$(printf 'dirtier\n')"
+
+# ------------------------------------------------------------ inject-context ----
+run_ctx() { RC=0; OUT="$(cd "$1" && printf '{"hook_event_name":"SessionStart"}' | bash "$CTX" 2>/dev/null)" || RC=$?; }
+valid_json() {
+  local rc=0
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$2" | jq -e . >/dev/null 2>&1 || rc=$?
+  elif command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$2" | python3 -c 'import sys,json;json.load(sys.stdin)' 2>/dev/null || rc=$?
+  else
+    ok "$1 (skipped — no jq/python3)"; return 0
+  fi
+  if [ "$rc" -eq 0 ]; then ok "$1"; else no "$1 (invalid JSON)"; fi
+}
+
+echo "inject-context — emits a SessionStart additionalContext payload:"
+G5="$(newrepo "$TMP/ctx1")"
+git -C "$G5" checkout -q -b orient/branch
+printf 'two\n' >> "$G5/a.txt"; printf 'new\n' > "$G5/b.txt"
+run_ctx "$G5"
+eq    "exit 0"                     "$RC" 0
+valid_json "output is valid JSON"  "$OUT"
+has   "correct hook event"         "$OUT" '"hookEventName":"SessionStart"'
+has   "carries additionalContext"  "$OUT" '"additionalContext"'
+has   "names the branch"           "$OUT" 'Branch: orient/branch'
+has   "counts uncommitted files"   "$OUT" 'Uncommitted files: 2'
+has   "lists recent commits"       "$OUT" 'c1'
+has   "reminds about CLAUDE.md"    "$OUT" 'CLAUDE.md'
+lacks "no upstream => no ahead/behind noise" "$OUT" 'behind'
+
+echo "inject-context — reports ahead/behind once an upstream exists:"
+git init -q --bare "$TMP/remote.git"
+git -C "$G5" add -A >/dev/null 2>&1; git -C "$G5" commit -qm c2
+git -C "$G5" remote add origin "$TMP/remote.git"
+git -C "$G5" push -q -u origin orient/branch >/dev/null 2>&1
+git -C "$G5" commit -q --allow-empty -m c3
+run_ctx "$G5"
+has "shows ahead count" "$OUT" 'ahead 1'
+has "shows behind count" "$OUT" 'behind 0'
+eq  "clean tree reports zero uncommitted" "$(printf '%s' "$OUT" | grep -c 'Uncommitted files: 0')" 1
+
+echo "inject-context — stays silent when there is nothing to inject:"
+run_ctx "$NOGIT"
+eq "exit 0 outside a git repo"       "$RC" 0
+eq "emits nothing outside a git repo" "$OUT" ""
+
+echo
+printf 'hook behavior corpus: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/test-protect-paths.sh
+++ b/scripts/test-protect-paths.sh
@@ -133,6 +133,8 @@ secret_blocked '/home/u/.aws/credentials'
 secret_blocked '/home/u/.ssh/id_ed25519'
 secret_blocked '/home/u/.netrc'
 secret_blocked '/repo/.htpasswd'
+secret_blocked '/repo/src/main/resources/application.properties'      # Spring (was a hole)
+secret_blocked '/repo/src/main/resources/application-prod.properties' # Spring profile (was a hole)
 secret_allowed '/repo/src/main.go'
 secret_allowed '/repo/README.md'
 secret_allowed '/repo/env.example'

--- a/sdlc/orchestrate.sh
+++ b/sdlc/orchestrate.sh
@@ -12,7 +12,7 @@
 # Env:
 #   SDLC_NO_PR=1     stop before opening a PR (inspect the branch yourself)
 #   SDLC_YOLO=1      Builder runs --permission-mode bypassPermissions (fully unattended)
-#   SDLC_BUDGET=8    total USD budget hint; per-Claude-step cap is BUDGET/4
+#   SDLC_BUDGET=8    total USD hard ceiling (halts the run, exit 3; needs jq); per-Claude-step cap is BUDGET/4
 #   SDLC_BASE=main   base branch for the PR (default: current branch)
 #   SDLC_CONVERGE=1  after review, loop fix→re-review until CLEAN or SDLC_MAX_FIX_ROUNDS (default 3)
 #   SDLC_GOAL="..."  run-until-condition: a FRESH, cheap model (maker/checker) judges this explicit
@@ -101,10 +101,21 @@ claude_step(){
   local name="$1" role="$2" model="$3" perm="$4" tools="$5" prompt="$6"
   log "$name  (claude · $model)"
   if [ "$HAVE_JQ" = 1 ]; then
+    # Cumulative hard ceiling: SDLC_BUDGET is a real cap, not a hint. A step never
+    # gets more than what's left of the total, and a run that has spent it halts
+    # (exit 3) instead of starting another step. Without jq there's no spend data,
+    # so only the per-step cap applies (the pre-run note says so).
+    local spent step_cap
+    spent="$(awk -F'\t' '{s+=$2} END{printf "%.4f", s+0}' "$COSTS" 2>/dev/null || echo 0)"
+    if awk "BEGIN{exit !($spent >= $BUDGET)}"; then
+      note "✋ budget ceiling: \$$spent spent ≥ \$$BUDGET total (SDLC_BUDGET) — halting before '$name'"
+      exit 3
+    fi
+    step_cap="$(awk "BEGIN{r=$BUDGET-$spent; printf \"%.2f\", (r<$STEP_BUDGET)?r:$STEP_BUDGET}")"
     local j="$RUN/$name.json"
     claude -p "$prompt" --model "$model" --append-system-prompt-file "$ROLES/$role" \
       --permission-mode "$perm" --allowedTools "$tools" \
-      --max-turns 25 --max-budget-usd "$STEP_BUDGET" \
+      --max-turns 25 --max-budget-usd "$step_cap" \
       --output-format json >"$j" 2>>"$RUN/orchestrate.log" || true
     jq -r '.result // ""' "$j" 2>/dev/null | tee "$RUN/$name.md"
     local c; c="$(jq -r '.total_cost_usd // 0' "$j" 2>/dev/null || echo 0)"
@@ -130,7 +141,7 @@ note "base:   $BASE   branch: $BRANCH"
 note "run:    $RUN   (build perm: $BUILD_PERM)"
 # Pre-run estimate (budgeting): each Claude step is hard-capped at $STEP_BUDGET; the run
 # can't exceed roughly that × the number of steps. QA is free; the Codex audit isn't tallied.
-note "spend:  ceiling ~\$$STEP_BUDGET per Claude step (cap), ~\$$BUDGET total budget hint$([ "$HAVE_JQ" = 1 ] && echo '' || echo '  · install jq for per-step spend analysis')"
+note "spend:  ceiling ~\$$STEP_BUDGET per Claude step (cap), ~\$$BUDGET total hard ceiling (halts, exit 3)$([ "$HAVE_JQ" = 1 ] && echo '' || echo '  · install jq for per-step spend analysis')"
 [ -n "$GOAL" ] && note "goal:   run until a fresh $GOAL_MODEL judges → \"$GOAL\" (≤ ${SDLC_MAX_FIX_ROUNDS:-3} rounds)"
 git checkout -b "$BRANCH" >/dev/null 2>&1 || { echo "could not create branch $BRANCH"; exit 2; }
 
@@ -343,8 +354,8 @@ if [ "$HAVE_JQ" = 1 ] && [ -f "$COSTS" ]; then
   STEPS="$(wc -l <"$COSTS" | tr -d ' ')"
   log "spend  (Claude steps; QA free, Codex audit not tallied)"
   awk -F'\t' '{printf "    %-14s $%.4f\n", $1, $2+0}' "$COSTS"
-  note "total Claude spend: \$$TOTAL   (budget hint \$$BUDGET, per-step cap \$$STEP_BUDGET)"
-  SPEND_LINE="**~\$$TOTAL** across $STEPS Claude steps (budget hint \$$BUDGET; QA free; Codex audit not tallied)"
+  note "total Claude spend: \$$TOTAL   (ceiling \$$BUDGET, per-step cap \$$STEP_BUDGET)"
+  SPEND_LINE="**~\$$TOTAL** across $STEPS Claude steps (ceiling \$$BUDGET; QA free; Codex audit not tallied)"
 fi
 
 # 7 · GATE — open a PR for human merge (never auto-merge/deploy)

--- a/sdlc/selftest.sh
+++ b/sdlc/selftest.sh
@@ -94,6 +94,21 @@ eq "budget 12 → 3.00 per step"        "$(step_budget 12)" "3.00"
 eq "budget 1 → 0.25 per step"         "$(step_budget 1)"  "0.25"
 eq "budget 3 → 0.75 per step"         "$(step_budget 3)"  "0.75"
 
+# ── 6b · Cumulative budget ceiling (mirror of orchestrate.sh claude_step guard) ──
+# BUDGET is a hard total: spent >= BUDGET halts (exit 3); a step's cap is
+# min(STEP_BUDGET, BUDGET - spent) so the last step can't overshoot the total.
+budget_gate() { # args: <spent> <budget> <step_budget> → "halt" | "cap X.XX"
+  local spent="$1" budget="$2" step="$3"
+  if awk "BEGIN{exit !($spent >= $budget)}"; then echo halt; return; fi
+  awk "BEGIN{r=$budget-$spent; printf \"cap %.2f\", (r<$step)?r:$step}"
+}
+echo "cumulative budget ceiling:"
+eq "nothing spent → full step cap"      "$(budget_gate 0 8 2.00)"      "cap 2.00"
+eq "mid-run, plenty left → step cap"    "$(budget_gate 3.10 8 2.00)"   "cap 2.00"
+eq "last dollar → capped to remainder"  "$(budget_gate 7.50 8 2.00)"   "cap 0.50"
+eq "spent == budget → halt"             "$(budget_gate 8.00 8 2.00)"   "halt"
+eq "overshoot → halt"                   "$(budget_gate 9.25 8 2.00)"   "halt"
+
 # ── 7 · SDLC_LITE mode skips the right stages ────────────────────────────────────
 # SDLC_LITE=1 emits a note saying audit+security are skipped; review+QA+gate remain.
 # We mirror the exact logic branch rather than calling orchestrate.sh itself.
@@ -220,6 +235,9 @@ ORCH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/orchestrate.sh"
 src_has() { if grep -Fq -- "$2" "$ORCH"; then ok "$1"; else bad "$1" "absent from orchestrate.sh" "$2"; fi; }
 echo "source anchors (mirrors must match orchestrate.sh):"
 src_has "per-step budget is BUDGET/4"               'BUDGET/4}'
+src_has "cumulative ceiling halts the run"          'exit !($spent >= $BUDGET)'
+src_has "step cap is min(step, remaining)"          '(r<$STEP_BUDGET)?r:$STEP_BUDGET'
+src_has "ceiling halt is exit 3"                    'halting before'
 src_has "fix-round cap default is 3"                'SDLC_MAX_FIX_ROUNDS:-3'
 src_has "diff-size haiku threshold default is 25"   'SDLC_HAIKU_DIFF_LINES:-25'
 src_has "tiny diff routes review to haiku"          'REVIEW_MODEL="haiku"'


### PR DESCRIPTION
Closes the remaining OPEN items from docs/15-competitive-audit.md (verified against code this session) + the 2026-07 field refresh.

## Changes
- **Guardrail**: Spring `application.properties` / `application-*.properties` added to the secret-write blocklist — the last unclosed item of the audit's secret-blocklist bullet. +2 corpus cases.
- **Budget**: `SDLC_BUDGET` promoted from per-step hint to enforced cumulative ceiling (roadmap §14): the run halts (exit 3) at the total; each step's cap is min(per-step, remaining). Selftest mirror + source anchors so drift fails CI.
- **Tests**: `scripts/test-hooks.sh` — 84 hermetic assertions for the 3 untested hooks (audit TEST-GAP/Medium), mutation-tested (JSONC-guard removal, destructive-stash swap, event-name change all caught), wired into doctor + ci.yml.
- **Docs honesty**: 61-case (bench) vs 147-case (bypass gate) corpus numbers disambiguated in README + docs/16; 2026-07 competitive refresh appended to docs/15 — kept generic, no third-party project names.

## Known limitation (documented, not fixed)
`format-on-edit.sh`'s JSONC guard matches `*/.vscode/*.json` (absolute paths only). Harmless today — the harness always passes absolute paths.

## Verification (all run locally, seen passing)
- hook behavior corpus: **84 passed, 0 failed**
- guardrail corpus: **147 passed, 0 failed**
- sdlc selftest: **75 passed, 0 failed**
- actions audit: **16 passed, 0 failed** · plugin sync: in sync · doctor: **140 ok / 0 warn / 0 error**