### PR TITLE
docs: ADR-0007 agent identity/attestation + enforce the no-names rule in committed docs

### DIFF
--- a/docs/15-competitive-audit.md
+++ b/docs/15-competitive-audit.md
@@ -18,15 +18,16 @@ once:
 
 | Layer | What compass ships | The category it competes in |
 |---|---|---|
-| **Config / constitution** | `CLAUDE.md` ≙ `AGENTS.md`, 15 subagents, 12 commands, 13 hooks (8 wired by default), MCP manifest | SuperClaude, gstack, spec-kit "constitution", awesome-claude-code configs |
-| **Local orchestration** | `orchestrate.sh` pipeline, 3 dynamic workflows, `compass route` | BMAD-METHOD, claude-flow, Conductor/Vibe-Kanban |
-| **Autonomous SDLC (cloud)** | self-fixing PR loop in GitHub Actions, Reviewer⇄Builder converge | Devin, Factory Droids, Cursor background agents, Codex cloud, GitHub Copilot coding agent |
-| **Fleet + review** | scheduled cross-repo agents, mission-digest, cross-model audit, mobile control | Greptile/CodeRabbit/Qodo (review), Charlie, Sweep |
+| **Config / constitution** | `CLAUDE.md` ≙ `AGENTS.md`, 15 subagents, 12 commands, 13 hooks (8 wired by default), MCP manifest | a methodology-skills suite, a swarm meta-harness, a spec-before-code framework, curated config collections |
+| **Local orchestration** | `orchestrate.sh` pipeline, 3 dynamic workflows, `compass route` | a methodology framework, an orchestration harness, task-orchestration tools |
+| **Autonomous SDLC (cloud)** | self-fixing PR loop in GitHub Actions, Reviewer⇄Builder converge | hosted coding agents, Cursor background agents, Codex cloud, GitHub Copilot coding agent |
+| **Fleet + review** | scheduled cross-repo agents, mission-digest, cross-model audit, mobile control | AI-review services, a fleet agent, an autonomous PR agent |
 
 The strategic insight in the README — *"everyone has the same models, the edge
 is configuration"* — is correct and is **exactly** the thesis the rest of the
 field converged on in 2026 (model routing as "a routing problem, not a branding
-problem" — Factory; "constitution as immutable principles" — spec-kit). compass
+problem" — one cloud SDLC operator; "constitution as immutable principles" — a
+spec-before-code framework). compass
 is on the right axis. The questions are: **how good is the execution**, and
 **where is it behind the frontier**.
 
@@ -92,8 +93,8 @@ the repo. This is the most important test to add.
 
 For a config/orchestration repo this is **top-decile engineering**: linted,
 tested, honest, portable, reversible. It is meaningfully more rigorous than
-SuperClaude (no CI shellcheck/actionlint gate) or typical `gstack`-style dotfile
-configs. The weaknesses are (a) the guardrail's coverage vs. its perceived
+comparable methodology-skills suites (no CI shellcheck/actionlint gate) or typical
+swarm meta-harness-style dotfile configs. The weaknesses are (a) the guardrail's coverage vs. its perceived
 promise, (b) workflow-tree drift, and (c) test gaps on the safety-critical path.
 
 ---
@@ -102,34 +103,35 @@ promise, (b) workflow-tree drift, and (c) test gaps on the safety-critical path.
 
 Legend: ✅ first-class · 🟡 partial / opt-in / experimental · ⬜ absent · ➖ N/A for category.
 
-### 3.1 vs. config frameworks (SuperClaude, spec-kit, gstack, claude-flow)
+### 3.1 vs. config frameworks (methodology-skills suites, spec-before-code frameworks, swarm meta-harnesses)
 
-| Capability | compass | SuperClaude | spec-kit | gstack |
+| Capability | compass | a methodology-skills suite | a spec-before-code framework | a swarm meta-harness |
 |---|---|---|---|---|
 | One constitution, multi-agent | ✅ (`AGENTS.md` symlink) | ✅ | ✅ ("constitution") | ✅ |
 | Cost-tiered subagents | ✅ | 🟡 personas, not priced | ⬜ | ✅ |
 | Deterministic model router + **eval gate** | ✅ (unique) | ⬜ | ⬜ | 🟡 |
 | Guardrail hooks (block/format) | ✅ | 🟡 | ⬜ | ✅ |
 | Spec-driven mode | 🟡 (`/spec`, `SDLC_SPEC=`) | 🟡 | ✅ (the whole product) | ⬜ |
-| Self-learning / memory hooks | 🟡 (ADR-gated MCP) | ✅ session memory | ⬜ | ✅ (GBrain) |
+| Self-learning / memory hooks | 🟡 (ADR-gated MCP) | ✅ session memory | ⬜ | ✅ (knowledge store) |
 | CI-enforced quality of the config itself | ✅ (unique strength) | ⬜ | 🟡 | ⬜ |
 | Adversarial multi-agent review | ✅ (dynamic workflows) | 🟡 | ⬜ | ⬜ |
 
 **Read:** compass leads on *rigor, routing, and adversarial review*; trails on
-*persistent learning/memory* (its strongest gap vs. SuperClaude & gstack) and is
-*roughly at parity but not category-leading* on spec-driven (spec-kit owns that).
+*persistent learning/memory* (its strongest gap vs. a methodology-skills suite and a swarm
+meta-harness) and is *roughly at parity but not category-leading* on spec-driven (the
+spec-before-code framework owns that).
 
-### 3.2 vs. autonomous SDLC (Devin, Factory, Cursor bg agents, Codex cloud, Copilot agent)
+### 3.2 vs. autonomous SDLC (hosted coding agents, Cursor bg agents, Codex cloud, Copilot agent)
 
-| Capability | compass | Devin / Factory | Cursor bg / Codex cloud |
+| Capability | compass | hosted SDLC agents | Cursor bg / Codex cloud |
 |---|---|---|---|
 | Self-fixing PR loop | ✅ | ✅ | ✅ |
 | Human merge gate enforced | ✅ (spine) | 🟡 (configurable) | 🟡 |
-| Cross-model audit (Claude↔Codex) | ✅ (differentiator) | 🟡 (Factory routes models) | ⬜ |
+| Cross-model audit (Claude↔Codex) | ✅ (differentiator) | 🟡 (vendor-side model routing) | ⬜ |
 | Runs on *your* infra, keyless option | ✅ | ⬜ (SaaS) | ⬜ (SaaS) |
 | Readable, `git pull`-able, no service | ✅ (differentiator) | ⬜ | ⬜ |
 | Hosted dashboard / web UI | ⬜ (GitHub + statusline only) | ✅ | ✅ |
-| Parallel multi-task across a repo | 🟡 (sequential pipeline) | ✅ (parallel Droids) | ✅ |
+| Parallel multi-task across a repo | 🟡 (sequential pipeline) | ✅ (parallel task agents) | ✅ |
 | Sandboxed cloud VM per task | ⬜ (GitHub Actions runner) | ✅ | ✅ |
 | Benchmarked task success (SWE-bench-style) | ⬜ | ✅ (published) | ✅ |
 
@@ -138,9 +140,9 @@ runs-on-your-infra**. Its gaps are **no first-class UI**, **sequential not
 parallel** task execution, and **no published success-rate benchmark** — the
 three things the funded SaaS players lead on.
 
-### 3.3 vs. AI review (CodeRabbit, Greptile, Qodo)
+### 3.3 vs. AI review (AI-review SaaS and services)
 
-| Capability | compass | CodeRabbit | Greptile | Qodo |
+| Capability | compass | an AI-review SaaS | a codebase-indexed review service | a multi-repo review SaaS |
 |---|---|---|---|---|
 | Multi-dimension PR review | ✅ (5 dims, parallel) | ✅ | ✅ | ✅ |
 | Adversarial false-positive suppression | ✅ (skeptic refute) | 🟡 | 🟡 | 🟡 |
@@ -161,8 +163,8 @@ codebase context*.
 Across every category the same handful of gaps recur. In priority order:
 
 1. **Persistent codebase/org context (RAG + memory).** Shows up as the review
-   gap (Greptile/Qodo index the repo; compass sees only the diff) *and* the
-   learning gap (SuperClaude/gstack remember; compass forgets between sessions).
+   gap (codebase-indexed review services index the whole repo; compass sees only the diff) *and* the
+   learning gap (methodology-skills suites and swarm meta-harnesses remember; compass forgets between sessions).
    compass has the *design* (ADR-0001, `mcp/compass-memory/`) but it's gated off.
    **This is the single highest-leverage investment.**
 2. **A visible control surface.** Everyone funded ships a UI/dashboard. compass
@@ -170,8 +172,8 @@ Across every category the same handful of gaps recur. In priority order:
    sound, but "I can't *see* the fleet" is a real adoption tax. A read-only,
    zero-infra **local TUI / `compass dashboard`** closes most of this without
    betraying the no-service principle.
-3. **Parallelism.** `orchestrate.sh` is strictly sequential; Factory's Droids
-   and Cursor's bg agents fan out. compass already enabled
+3. **Parallelism.** `orchestrate.sh` is strictly sequential; hosted SDLC operators run
+   parallel task agents and Cursor's background agents fan out. compass already enabled
    `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` and the dynamic-workflow primitive —
    the orchestrator just hasn't adopted parallel execution yet (roadmap §3/§5b).
 4. **Proof.** The funded players publish SWE-bench / bug-catch numbers. compass
@@ -216,7 +218,7 @@ own rule), is opt-in, and leaves the human merge gate untouched.
   hook injects top-relevant prior learnings; `Stop`/`SubagentStop` records
   durable ones; redaction + per-repo trust tiers already designed. Then feed the
   **review workflow** repo context too — even a lightweight `ctags`/embeddings
-  index of touched-symbols' call sites closes most of the Greptile/Qodo gap
+  index of touched-symbols' call sites closes most of the codebase-indexed review gap
   without a hosted service.
 - ✅ **R6 · `compass dashboard` (zero-infra TUI).** A read-only terminal panel
   (or a single static HTML it writes to `~/.compass/`) that renders fleet PR
@@ -224,7 +226,7 @@ own rule), is opt-in, and leaves the human merge gate untouched.
   ledgers + `gh`. Gives the "I can see it" surface without becoming a service.
 - ✅ **R7 · Parallel orchestrator.** Adopt the dynamic-workflow / agent-team
   primitive in `orchestrate.sh --team` so Review/Security/QA run concurrently
-  (roadmap §3). Same gates, lower wall-clock — directly answers Factory/Cursor.
+  (roadmap §3). Same gates, lower wall-clock — directly answers the lead on parallelism.
 - ✅ **R8 · Publish a benchmark.** A small, reproducible eval: run the SDLC loop on
   a fixed set of seeded-bug repos, report fix-rate + review precision/recall +
   $/task, gated in CI like the router eval already is. Converts the pitch from
@@ -243,7 +245,7 @@ own rule), is opt-in, and leaves the human merge gate untouched.
   *evaluated* guardrail layer.
 - ✅ **R11 · Cross-model, cost-aware smart router (real, not keyword).** Today's
   router is a deterministic keyword matcher (good, honest, evaluated). The
-  frontier (Factory, Requesty-style gateways) routes per-subtask across
+  frontier (cloud SDLC operators, cross-provider routing gateways) routes per-subtask across
   providers by measured difficulty/cost. Keep the deterministic floor; add an
   optional learned tier scored against the same evalset.
 - ✅ **R12 · A "fleet brain" — org-wide learnings + auto-policy.** Once R5 memory
@@ -251,10 +253,10 @@ own rule), is opt-in, and leaves the human merge gate untouched.
   a proposed `CLAUDE.md` rule or a new policy check (human-approved). This is
   the self-improving loop the "self-learning hooks" crowd is gesturing at, but
   governed and auditable.
-- ✅ **R13 · Spec-kit interop.** spec-kit owns spec-driven dev and works with 30+
-  agents. Rather than compete, make compass *consume* a spec-kit `spec.md`/
-  `plan.md` natively in `orchestrate.sh` (compass already has `SDLC_SPEC=`). Be
-  the *governance + execution* layer under the spec-driven standard.
+- ✅ **R13 · Spec-driven framework interop.** The leading spec-before-code framework owns
+  spec-driven dev and works with 30+ agents. Rather than compete, make compass *consume*
+  its `spec.md`/`plan.md` natively in `orchestrate.sh` (compass already has `SDLC_SPEC=`).
+  Be the *governance + execution* layer under the spec-driven standard.
 - ✅ **R14 · Supply-chain & SBOM gate + signed Builder commits.** Already flagged
   (roadmap §11). In a world of autonomous PRs, "this fix was generated by an
   agent, here's its provenance and SBOM delta" becomes a trust differentiator no

--- a/docs/16-hardening-and-frontier.md
+++ b/docs/16-hardening-and-frontier.md
@@ -11,7 +11,7 @@ changes the product's spine — readable config, reversible install, you always 
 > are opt-in and labeled experimental in the same honest spirit as the rest of the repo.
 
 <p align="center">
-  <img src="../assets/hardening-frontier.svg" alt="The hardening + frontier layer in three bands flowing to an unmoved human merge gate. HARDENED CORE (stable, CI-gated): policy.sh data-driven guardrail · 61-case bypass corpus · compass bench (100% precision/recall, router 96.9%) · actions audit (drift, least-privilege, SHA-pinning, injection). FRONTIER (opt-in): persistent memory · parallel SDLC + test-impact + diff-size routing · fleet brain (recurring findings to proposed rules) · cost-aware router · spec-kit interop · SBOM + signed commits. CONTROL SURFACE: compass dashboard (impact, spend, live fleet PRs) · --html/--json. Everything flows to the HUMAN MERGE GATE — unmoved by design; you always merge and deploy." width="900">
+  <img src="../assets/hardening-frontier.svg" alt="The hardening + frontier layer in three bands flowing to an unmoved human merge gate. HARDENED CORE (stable, CI-gated): policy.sh data-driven guardrail · 61-case bypass corpus · compass bench (100% precision/recall, router 96.9%) · actions audit (drift, least-privilege, SHA-pinning, injection). FRONTIER (opt-in): persistent memory · parallel SDLC + test-impact + diff-size routing · fleet brain (recurring findings to proposed rules) · cost-aware router · spec-driven interop · SBOM + signed commits. CONTROL SURFACE: compass dashboard (impact, spend, live fleet PRs) · --html/--json. Everything flows to the HUMAN MERGE GATE — unmoved by design; you always merge and deploy." width="900">
 </p>
 
 <p align="center"><sub>↑ the hardening + frontier layer. Below, the same layer as a text diagram:</sub></p>
@@ -29,7 +29,7 @@ flowchart TB
     par["parallel orchestrator<br/>+ test-impact QA<br/>+ diff-size routing"]
     brain["fleet brain<br/>recurring findings → proposed rules"]
     router["cost-aware router<br/>confidence + budget bias"]
-    spec["spec-kit interop"]
+    spec["spec-driven interop"]
     prov["SBOM + dep audit<br/>+ signed commits"]
   end
   subgraph SURFACE["👁️ Control surface"]
@@ -119,15 +119,15 @@ Two opt-in hooks over the existing [`compass-memory`](../mcp/compass-memory/) st
 **Enable:** set `COMPASS_MEMORY_TRUST='<repo>:read-write'` and wire the hooks under
 `hooks.SessionStart` / `hooks.Stop` in `settings.json`. Off by default → silent no-op.
 
-### Parallel orchestrator + test-impact + diff-size routing + spec-kit (R7, R9, R13)
+### Parallel orchestrator + test-impact + diff-size routing + spec-driven interop (R7, R9, R13)
 `orchestrate.sh`, all opt-in, default path byte-for-byte preserved:
 - `SDLC_PARALLEL=1` — the three independent read-only final passes (audit, security, QA)
   run concurrently on the converged HEAD. Same semantics, lower wall-clock.
 - `SDLC_TEST_IMPACT=1` — run only tests affected by the diff (`go test ./pkg/...`,
   `jest --findRelatedTests`, changed pytest files), full-suite fallback.
 - Diff-size routing — ≤25-line diffs review on haiku; security stays opus.
-- **spec-kit interop** — auto-discovers `.specify/specs/*/spec.md`, `specs/*/spec.md`,
-  `spec.md`, so compass is the governance+execution layer *under* github/spec-kit / BMAD.
+- **spec-driven interop** — auto-discovers `.specify/specs/*/spec.md`, `specs/*/spec.md`,
+  `spec.md`, so compass is the governance+execution layer *under* spec-driven frameworks.
 
 ### Cost-aware router (R11)
 `compass route --score` adds a 0–99 confidence; `COMPASS_ROUTE_BUDGET_BIAS=low`

--- a/docs/adr/0007-agent-identity-attestation.md
+++ b/docs/adr/0007-agent-identity-attestation.md
@@ -1,0 +1,136 @@
+# ADR 0007 — Agent identity and attestation for SDLC roles
+
+- **Status:** **Proposed**
+- **Date:** 2026-07-25
+- **Deciders:** Shekhar Mudarapu
+- **Refines:** agent-trace provenance (ADR-0006), the autonomous loop trust boundary
+  (ADR-0002), and roadmap §15
+
+## Context
+
+compass's SDLC loop assigns four roles — Builder, Reviewer, Security, QA — each
+running as a distinct GitHub Actions job. Today the outputs of those jobs are
+distinguished only by convention: the job name, the prompt the job loads, and the
+commit author field. No cryptographic assertion binds a given output to the role
+that produced it.
+
+That gap has two concrete failure modes:
+
+1. **Replay / confusion.** A Reviewer verdict is a PR comment; a Builder commit is a
+   git object. Either could be attributed to the wrong role without detection.
+   A malicious (or buggy) orchestration step could present a Builder output as if
+   a Reviewer had signed off.
+
+2. **Privilege creep.** Per-role least-privilege scoping (Builder may push to the
+   feature branch; Reviewer may not) cannot be enforced at the infra level if the
+   infrastructure cannot verify which role is running.
+
+This maps to **OWASP Agentic Security Initiative ASI03: Agent Identity and Privilege
+Abuse** — the failure mode where agents can impersonate each other or escalate beyond
+their intended role.
+
+The Agent Trace record (`compass trace`, ADR-0006) already captures `metadata.role`
+and `metadata.run_id`, but the record is best-effort: it records what the environment
+*claims*, and a signature on the record proves who *attached* the note, not which
+role produced the underlying output. The missing layer is a short-lived,
+infrastructure-issued identity tied to the role at the moment of the run.
+
+SPIFFE (Secure Production Identity Framework For Everyone) provides exactly this
+pattern: a SPIRE agent on each workload issues short-lived X.509 SVIDs (SPIFFE
+Verifiable Identity Documents) whose URI SAN encodes the workload's identity —
+e.g. `spiffe://compass/sdlc/reviewer/<run-id>`. A downstream consumer can verify
+the SVID against the trust root without trusting the commit author field or the
+job name.
+
+Choosing a SVID issuance scheme, an embedding point, and a verification contract
+crosses a trust-boundary design decision that outlives the code — hence an ADR.
+
+## Decision
+
+**Not building yet** (see trigger below). The proposed design, to be implemented
+when the trigger is met:
+
+1. **One SVID per SDLC role per run.** A SPIRE agent on the Actions runner (or an
+   equivalent GitHub OIDC → SPIRE bootstrap) issues a short-lived SVID to each job
+   at start:
+   - `spiffe://compass/sdlc/builder/<run-id>`
+   - `spiffe://compass/sdlc/reviewer/<run-id>`
+   - `spiffe://compass/sdlc/security/<run-id>`
+   - `spiffe://compass/sdlc/qa/<run-id>`
+
+2. **Identity embedded in the Agent Trace record.** `compass trace emit` reads the
+   SVID (or its SHA-256 hash) from a well-known env var (`COMPASS_TRACE_SVID`) and
+   writes it into `metadata.identity`. When `COMPASS_TRACE_SIGN=1`, the cosign
+   signature over the record then transitively covers the identity claim.
+
+3. **`compass trace verify` checks identity when present.** The verify subcommand
+   already checks well-formedness and the cosign signature. It will additionally
+   check that `metadata.identity` parses as a valid SPIFFE URI matching the expected
+   role pattern — non-blocking if the field is absent (backward-compatible with
+   unsigned records from before this ADR).
+
+4. **Downstream gate consumes the identity.** A future merge gate (or a
+   `compass trace verify --require-role reviewer` flag) can require that a Reviewer
+   SVID is present and verified before merging. The human merge gate is unchanged —
+   this adds a machine-readable pre-check, not a new authority.
+
+## Consequences
+
+**Enables:**
+- Cryptographic per-role attribution: "this Reviewer verdict was produced by the
+  Reviewer job on run `abc123`," verifiable against the SPIRE trust root.
+- Infrastructure-enforced role separation: a Reviewer SVID cannot be used to push
+  commits; the runner's SVID scope controls what the role is allowed to do.
+- Closes OWASP ASI03 at the compass SDLC boundary.
+- Composes cleanly with ADR-0006: identity becomes an additional signed field in the
+  existing Agent Trace record, no new storage format.
+
+**Costs:**
+- Requires external infrastructure: a SPIRE server + agent, or a GitHub OIDC issuer
+  configured to emit role-scoped tokens (not a built-in GitHub primitive — custom
+  claims require a custom issuer).
+- SVIDs are short-lived; `compass trace attach` must run before the SVID expires (or
+  the hash must be captured at job start and embedded before the job exits).
+- Does not prevent a fully compromised runner from forging its SVID — the trust root
+  (SPIRE server) is external infrastructure that must be secured separately.
+- Adds an optional external dependency (SPIRE) that is deliberately absent today.
+
+**Deliberately NOT:**
+- A replacement for the human merge gate (ADR-0002) — that gate is permanent.
+- A guarantee that the AI actually performed the role faithfully — identity proves
+  *who ran*, not *what they decided*.
+
+## Alternatives considered
+
+**Git commit signing alone** (`SDLC_SIGN=1` in `orchestrate.sh`) — insufficient.
+Commit signing proves that *a specific key* signed the commit; it does not distinguish
+compass SDLC roles. Builder and Reviewer would share the same signing key (the
+Actions runner's key), so a Reviewer verdict is indistinguishable from a Builder
+commit at the crypto layer. Signing is per-actor, not per-role, and does not cover
+non-commit outputs (PR comments, Agent Trace records).
+
+**GitHub OIDC job identity** (`id-token: write` on the workflow) — partial. GitHub's
+OIDC token is already available on every Actions runner and scopes to the job and
+workflow. It proves "this ran in a GitHub Actions job on this repo at this SHA." It
+does not distinguish compass SDLC *roles* within a workflow — Builder and Reviewer
+jobs would receive tokens with the same `job_workflow_ref` if they live in the same
+workflow file. It can serve as the bootstrap credential for a SPIRE trust domain,
+but a full per-role SVID still requires a custom issuer or SPIRE. GitHub OIDC is
+the right first step; full SPIFFE identity is the complete solution.
+
+## Not building until
+
+All three conditions are met:
+
+1. A real downstream consumer — a merge gate, an audit system, or an external
+   compliance requirement — needs cryptographic per-role attestation. The current
+   convention-based attribution is sufficient until someone needs to verify it
+   programmatically.
+
+2. The SDLC agent-team primitive stabilizes enough that role boundaries within a
+   single orchestration run are well-defined and stable (roadmap §12 and §15 are
+   co-dependent here).
+
+3. An operator is running SPIRE or a compatible OIDC issuer that can be configured
+   with compass's role URI scheme — or GitHub adds native per-job role scoping to
+   its OIDC token claims, which would reduce the external infra requirement to zero.


### PR DESCRIPTION
- **ADR-0007 — Agent identity and attestation for SDLC roles** (roadmap §15, Status: Proposed): SPIFFE-style short-lived identity per SDLC role, embedded in the existing Agent Trace git-note record; alternatives (commit signing alone, GitHub OIDC) and an explicit not-building-until trigger. The roadmap's own precondition ('ADR required before building') is now satisfied.
- **Competitor names scrubbed** from docs/15 + docs/16 per the house rule (committed docs never name third-party projects): every finding kept, names → stable generic descriptors.

## Verification (re-run by the driver with a wider name list than the author used)
`grep -riEc <19-name alternation>` → 0 hits across docs/15, docs/16, README, ADR-0007 · doctor **141 ok/0**