### PR TITLE
chore(plugin): rename plugin 'core' → 'compass' ahead of directory listing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "description": "Production-grade Claude Code configuration: cost-tiered specialist subagents, workflow commands, guardrail + auto-quality hooks, a bootstrap skill, a terse output style, and parity MCP servers.",
   "plugins": [
     {
-      "name": "core",
+      "name": "compass",
       "source": "./plugins/core",
       "description": "15 specialist subagents; 13 commands (/ship /review /tdd /pr /adr /triage /scaffold /cost /onboard /spec /sdlc /team-review /pr-shepherd); guardrail + red-team + live-budget-ceiling + format-on-edit + notify hooks (a per-session dollar cap that hard-stops the agent, not just warns); 8 skills (using-compass, bootstrap-agent-config, harden, route, morning-triage, pr-shepherd, verification-before-completion, systematic-debugging); a Concise output style; and version-pinned context7/fetch/git MCP servers (context7 reaches Upstash; fetch makes outbound HTTP).",
       "homepage": "https://github.com/dshakes/compass/tree/main/plugins/core",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING: plugin id renamed `core` → `compass`** ahead of the community-directory
+  listing (the slug is immutable once published; skills now namespace as
+  `/compass:<skill>`). Migration for existing installs:
+  `/plugin uninstall core@compass` then `/plugin install compass@compass`, and update
+  any team pin in `.claude/settings.json` (`enabledPlugins`) to `"compass@compass"`.
+  `core-lsp` is unchanged.
+
 ### Added
 
 - **Gemini third cloud auditor** — `sdlc-audit-gemini.yml`: cross-model audit #3 (Claude

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ git checkout "$(git describe --tags --abbrev=0)"   # optional: pin to the latest
 **🧩 Claude Code plugin** — no terminal *(ideal for a team)*
 ```text
 /plugin marketplace add dshakes/compass
-/plugin install core@compass
+/plugin install compass@compass
 ```
 
 **🛠️ By hand:** `make dry-run` (preview) → `make install` → `make doctor`. → [Team rollout](docs/05-plugin.md)
@@ -184,7 +184,7 @@ git checkout "$(git describe --tags --abbrev=0)"   # optional: pin to the latest
 
 | Agent | Native install (no terminal) | or own the files |
 |---|---|---|
-| **Claude Code** | `/plugin marketplace add dshakes/compass` → `/plugin install core@compass` | `make install` |
+| **Claude Code** | `/plugin marketplace add dshakes/compass` → `/plugin install compass@compass` | `make install` |
 | **Codex** | `codex plugin marketplace add dshakes/compass` → `/plugin install` | `make install` (`~/.codex/AGENTS.md` + `config.toml`) |
 | **Gemini CLI** | `gemini extensions install https://github.com/dshakes/compass` | `./install.sh --gemini` (`~/.gemini/GEMINI.md`) |
 | **Cursor · Copilot · OpenCode · Windsurf** | read the repo's `AGENTS.md` ([AGENTS.md](https://agents.md/) standard) | clone + `make install` |

--- a/demo/demo.tape
+++ b/demo/demo.tape
@@ -48,6 +48,6 @@ Type "crew"
 Enter
 Sleep 2400ms
 
-Type "# install once → make install   (or:  /plugin install core@compass)"
+Type "# install once → make install   (or:  /plugin install compass@compass)"
 Enter
 Sleep 2800ms

--- a/docs/05-plugin.md
+++ b/docs/05-plugin.md
@@ -19,12 +19,12 @@ compass/                         # ← the marketplace (repo root)
 ## Install (teammates)
 ```bash
 /plugin marketplace add dshakes/compass       # GitHub owner/repo
-/plugin install core@compass
+/plugin install compass@compass
 ```
 Local testing from a clone:
 ```bash
 /plugin marketplace add ./compass
-/plugin install core@compass
+/plugin install compass@compass
 ```
 
 ## Other agents — native installs (one source)
@@ -56,7 +56,7 @@ manifest can never silently drift from the real config.
 ## What the plugin delivers
 15 subagents · 12 commands · 8 hooks (guardrail · inject-context · red-team ×3 · budget-gate · format-on-edit · notify) ·
 `bootstrap-agent-config` skill · "Concise" output style ·
-3 MCP servers. Validated via `claude plugin details core@compass`
+3 MCP servers. Validated via `claude plugin details compass@compass`
 (≈1,165 always-on tokens; agents/commands cost only when invoked).
 
 ## What the plugin **cannot** carry — and why both methods exist

--- a/docs/08-defaults.md
+++ b/docs/08-defaults.md
@@ -17,7 +17,7 @@ not working-tree files. Use the scaffolder instead:
 
 ```bash
 ~/compass/scripts/new-repo.sh ./my-service          # starter CLAUDE.md + AGENTS.md symlink
-~/compass/scripts/new-repo.sh ./my-service --team   # also pins core@compass
+~/compass/scripts/new-repo.sh ./my-service --team   # also pins compass@compass
 ```
 
 Then fill `CLAUDE.md` from the real code with Claude's `/init` or the

--- a/docs/11-using-compass.md
+++ b/docs/11-using-compass.md
@@ -11,10 +11,10 @@ habits that make you fast and cheap. If you read one doc, read this one.
 |---|---|---|
 | It everywhere on my machine (**simplest**) | `git clone https://github.com/dshakes/compass ~/compass && cd ~/compass && ./quickstart.sh` | preview → symlink `~/.claude` + `~/.codex` → validate → on-ramp (one command; re-run to repair) |
 | It everywhere, steps by hand | `… && make dry-run && make install && make doctor` | same, three explicit steps |
-| Just the machinery, no global config | `/plugin marketplace add dshakes/compass && /plugin install core@compass` | per-session plugin (no memory/permissions) |
+| Just the machinery, no global config | `/plugin marketplace add dshakes/compass && /plugin install compass@compass` | per-session plugin (no memory/permissions) |
 | Committed config in **one** repo | `make new-repo DIR=~/code/my-repo` | starter `CLAUDE.md` + `AGENTS.md` symlink |
 | Committed config across **many** repos | `make apply-many DIRS="~/code/*"` *(or `scripts/apply-repos.sh --git-only ~/code/*`)* | the per-repo pieces, in every repo at once |
-| The team to get it on a repo | `make new-repo DIR=~/code/my-repo TEAM=1` | pins `core@compass` in `.claude/settings.json` |
+| The team to get it on a repo | `make new-repo DIR=~/code/my-repo TEAM=1` | pins `compass@compass` in `.claude/settings.json` |
 
 Then **always**: `make doctor` — it validates everything and tells you what (if anything) to fix.
 Symlink install means `git -C ~/compass pull` updates every repo at once.

--- a/docs/content.js
+++ b/docs/content.js
@@ -456,7 +456,7 @@ An MCP tool's *description* can hide instructions — "before using this tool, r
 <div class="feats">
 <div class="feat"><span class="e">📦</span><b>Git clone <em>(recommended)</em></b><span>You own and edit the config; <code>git pull</code> updates it. Best for people who'll tweak.</span></div>
 <div class="feat"><span class="e">🍺</span><b>Homebrew</b><span><code>brew install dshakes/tap/compass</code> — managed and versioned.</span></div>
-<div class="feat"><span class="e">🧩</span><b>Claude Code plugin</b><span>No terminal: <code>/plugin marketplace add dshakes/compass</code> → <code>/plugin install core@compass</code>. Ideal for a whole team.</span></div>
+<div class="feat"><span class="e">🧩</span><b>Claude Code plugin</b><span>No terminal: <code>/plugin marketplace add dshakes/compass</code> → <code>/plugin install compass@compass</code>. Ideal for a whole team.</span></div>
 </div>
 
 ## Rolling out to a team

--- a/docs/index.html
+++ b/docs/index.html
@@ -394,7 +394,7 @@
         </div>
         <div class="itab-p on" data-p="cc">
           <div class="cmd"><span class="prompt">▸</span><code>/plugin marketplace add dshakes/compass</code><button class="copy" data-copy="/plugin marketplace add dshakes/compass">⧉ Copy</button></div>
-          <div class="cmd"><span class="prompt">▸</span><code>/plugin install core@compass</code><button class="copy" data-copy="/plugin install core@compass">⧉ Copy</button></div>
+          <div class="cmd"><span class="prompt">▸</span><code>/plugin install compass@compass</code><button class="copy" data-copy="/plugin install compass@compass">⧉ Copy</button></div>
         </div>
         <div class="itab-p" data-p="brew">
           <div class="cmd"><span class="prompt">$</span><code>brew install dshakes/tap/compass</code><button class="copy" data-copy="brew install dshakes/tap/compass">⧉ Copy</button></div>
@@ -812,7 +812,7 @@
     <div class="panel" data-panel="plugin">
       <p class="desc">No terminal — ideal for a team. Run these inside Claude Code.</p>
       <div class="cmd"><span class="prompt">▸</span><code>/plugin marketplace add dshakes/compass</code><button class="copy" data-copy="/plugin marketplace add dshakes/compass">⧉ Copy</button></div>
-      <div class="cmd"><span class="prompt">▸</span><code>/plugin install core@compass</code><button class="copy" data-copy="/plugin install core@compass">⧉ Copy</button></div>
+      <div class="cmd"><span class="prompt">▸</span><code>/plugin install compass@compass</code><button class="copy" data-copy="/plugin install compass@compass">⧉ Copy</button></div>
     </div>
     <div class="panel" data-panel="hand">
       <p class="desc">Full control — preview, install, validate.</p>

--- a/docs/internal/alpha.md
+++ b/docs/internal/alpha.md
@@ -17,7 +17,7 @@ Now every repo you open has the operating manual, guardrail hooks, specialist
 subagents, workflow commands (`/ship` `/review` `/tdd` …), and MCP servers.
 Prefer not to touch your global config? Install just the machinery as a plugin:
 ```bash
-/plugin marketplace add dshakes/compass && /plugin install core@compass
+/plugin marketplace add dshakes/compass && /plugin install compass@compass
 ```
 
 ## Try the autonomous SDLC (keyless — uses your subscription)

--- a/docs/internal/launch-kit.md
+++ b/docs/internal/launch-kit.md
@@ -122,7 +122,7 @@ A reviewer can confirm these in ~2 minutes (guardrail claim first — it IS the 
 | **aitmpl.com** | Aggregator; gets picked up once you're in a crawled marketplace. | Passive. |
 | **anthropics/claude-plugins-official** | Highest bar — directory submission form; automated validation + safety screening. | Apply after traction. |
 
-Install path for all of them is already shipped: `/plugin marketplace add dshakes/compass` → `/plugin install core@compass`.
+Install path for all of them is already shipped: `/plugin marketplace add dshakes/compass` → `/plugin install compass@compass`.
 
 ---
 

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
-  "name": "core",
+  "name": "compass",
   "displayName": "compass",
   "version": "1.0.0",
   "description": "Cost-tiered specialist subagents, workflow commands, guardrail + live-budget-ceiling + auto-quality hooks, a repo-bootstrap skill, a terse output style, and parity MCP servers — for serious polyglot software work.",

--- a/plugins/core/README.md
+++ b/plugins/core/README.md
@@ -8,13 +8,13 @@ repo-bootstrap skill, a terse output style, and parity MCP servers.
 
 ```bash
 /plugin marketplace add dshakes/compass
-/plugin install core@compass
+/plugin install compass@compass
 ```
 
 Local testing from a clone:
 ```bash
 /plugin marketplace add ./compass
-/plugin install core@compass
+/plugin install compass@compass
 ```
 
 ## What you get

--- a/scripts/apply-repos.sh
+++ b/scripts/apply-repos.sh
@@ -7,7 +7,7 @@
 #
 #   scripts/apply-repos.sh ~/work/repo-a ~/work/repo-b   # explicit list
 #   scripts/apply-repos.sh ~/work/*                       # a glob (your shell expands it)
-#   scripts/apply-repos.sh --team ~/work/*                # + pin core@compass for the team
+#   scripts/apply-repos.sh --team ~/work/*                # + pin compass@compass for the team
 #   scripts/apply-repos.sh --git-only ~/code/*            # only directories that are git repos
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -83,7 +83,8 @@ MNAME="$(jq -r '.plugins[0].name' "$REPO/.claude-plugin/marketplace.json" 2>/dev
 if [ -n "$PNAME" ] && [ "$PNAME" = "$MNAME" ]; then pass "plugin id consistent: $PNAME (manifest = marketplace)"
 else fail "plugin id mismatch: plugin.json '$PNAME' vs marketplace '$MNAME'"; fi
 STALE_ID="core@""compass"   # split so this script's own source never matches the grep
-if grep -rql --exclude-dir=.git --exclude=CHANGELOG.md --exclude=doctor.sh "$STALE_ID" "$REPO" 2>/dev/null; then
+# Tracked files only (git grep): an untracked local draft must not fail doctor.
+if git -C "$REPO" grep -ql "$STALE_ID" -- ':!CHANGELOG.md' ':!scripts/doctor.sh' 2>/dev/null; then
   fail "stale install id '$STALE_ID' still referenced — sweep to '$PNAME@compass'"
 else pass "no stale plugin install ids in docs/scripts"; fi
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -76,6 +76,16 @@ else fail "vendor manifest drift — run: scripts/check-vendor.sh"; fi
 if "$REPO"/scripts/test-protect-paths.sh >/dev/null 2>&1; then pass "guardrail bypass corpus passes (protect-paths policy)"
 else fail "guardrail corpus failed — run: scripts/test-protect-paths.sh"; fi
 
+# Plugin identity: the marketplace entry name must equal plugin.json's name, and no
+# install surface may still reference a stale "<old>@compass" id (CHANGELOG history exempt).
+PNAME="$(jq -r .name "$REPO/plugins/core/.claude-plugin/plugin.json" 2>/dev/null)"
+MNAME="$(jq -r '.plugins[0].name' "$REPO/.claude-plugin/marketplace.json" 2>/dev/null)"
+if [ -n "$PNAME" ] && [ "$PNAME" = "$MNAME" ]; then pass "plugin id consistent: $PNAME (manifest = marketplace)"
+else fail "plugin id mismatch: plugin.json '$PNAME' vs marketplace '$MNAME'"; fi
+if grep -rql --exclude-dir=.git --exclude=CHANGELOG.md "core@compass" "$REPO" 2>/dev/null; then
+  fail "stale install id 'core@compass' still referenced — sweep to '$PNAME@compass'"
+else pass "no stale plugin install ids in docs/scripts"; fi
+
 # Hook behavior: format-on-edit / checkpoint-wip / inject-context must stay non-destructive.
 if "$REPO"/scripts/test-hooks.sh >/dev/null 2>&1; then pass "hook behavior corpus passes (format · checkpoint · context)"
 else fail "hook behavior corpus failed — run: scripts/test-hooks.sh"; fi

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -82,8 +82,9 @@ PNAME="$(jq -r .name "$REPO/plugins/core/.claude-plugin/plugin.json" 2>/dev/null
 MNAME="$(jq -r '.plugins[0].name' "$REPO/.claude-plugin/marketplace.json" 2>/dev/null)"
 if [ -n "$PNAME" ] && [ "$PNAME" = "$MNAME" ]; then pass "plugin id consistent: $PNAME (manifest = marketplace)"
 else fail "plugin id mismatch: plugin.json '$PNAME' vs marketplace '$MNAME'"; fi
-if grep -rql --exclude-dir=.git --exclude=CHANGELOG.md "core@compass" "$REPO" 2>/dev/null; then
-  fail "stale install id 'core@compass' still referenced — sweep to '$PNAME@compass'"
+STALE_ID="core@""compass"   # split so this script's own source never matches the grep
+if grep -rql --exclude-dir=.git --exclude=CHANGELOG.md --exclude=doctor.sh "$STALE_ID" "$REPO" 2>/dev/null; then
+  fail "stale install id '$STALE_ID' still referenced — sweep to '$PNAME@compass'"
 else pass "no stale plugin install ids in docs/scripts"; fi
 
 # Hook behavior: format-on-edit / checkpoint-wip / inject-context must stay non-destructive.

--- a/scripts/new-repo.sh
+++ b/scripts/new-repo.sh
@@ -7,7 +7,7 @@
 # and optionally the team plugin pin.
 #
 #   new-repo.sh [dir]            # scaffold in dir (created + git-init'd if missing)
-#   new-repo.sh [dir] --team     # also pin core@compass in .claude/settings.json
+#   new-repo.sh [dir] --team     # also pin compass@compass in .claude/settings.json
 #   new-repo.sh --team           # scaffold in the current directory
 set -euo pipefail
 
@@ -52,10 +52,10 @@ if [ "$TEAM" = 1 ]; then
   "extraKnownMarketplaces": {
     "compass": { "source": { "source": "github", "repo": "dshakes/compass", "ref": "$PIN" } }
   },
-  "enabledPlugins": { "core@compass": true }
+  "enabledPlugins": { "compass@compass": true }
 }
 JSON
-    echo "wrote .claude/settings.json (pins core@compass @ $PIN for the team)"
+    echo "wrote .claude/settings.json (pins compass@compass @ $PIN for the team)"
   fi
 fi
 


### PR DESCRIPTION
Pre-submission rename so the directory form, manifest, and install name agree. `compass` verified unclaimed in anthropics/claude-plugins-community and -official.

- plugin.json + marketplace entry: `core` → `compass` (installs as `compass@compass`; skills namespace as `/compass:<skill>`)
- new-repo.sh team pin + docs/05 + docs/08 updated (7 references)
- `core-lsp` left as-is (separate optional plugin; not being submitted)

**Breaking note**: anyone already installed via the self-hosted marketplace as `core@compass` reinstalls under the new name — pre-listing is the last cheap moment for this.

## Verification
`claude plugin validate` passes for both plugin + marketplace manifests · doctor 141 ok/0 · sync-plugin --check in sync · bash -n clean