### PR TITLE
feat(loops): pr-shepherd scheduled routine — unattended twice-daily PR handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **`pr-shepherd` scheduled routine** — `compass schedule add pr-shepherd --twice-daily`
+  runs the shepherd unattended on your machine (09:07/17:07 while awake): reads every open
+  PR's failing checks, fixes mechanical + real defects PROD-grade (tests required, gate run
+  locally before push, three-strikes cap), comments GA-tone explanations, and squash-merges
+  when all checks are green. Bounded (60 turns / $3 / 45m per run, overridable), fork PRs
+  read-only, never force-pushes, never closes unmerged PRs. Rails are asserted by
+  `test-cli.sh`, and the branch ruleset enforces required checks server-side regardless.
+
 ### Changed
 
 - **BREAKING: plugin id renamed `core` → `compass`** ahead of the community-directory

--- a/claude/skills/pr-shepherd/SKILL.md
+++ b/claude/skills/pr-shepherd/SKILL.md
@@ -74,6 +74,11 @@ resumes instead of re-diagnosing. **The agent forgets; the repo does not.**
 ## Schedule
 
 - On demand: `/pr-shepherd`.
-- Interval: `/loop 15m /pr-shepherd` — each firing re-reads state, handles what changed.
+- Interval (session open): `/loop 15m /pr-shepherd` — each firing re-reads state, handles
+  what changed.
+- Unattended cadence (no session open): `compass schedule add pr-shepherd --twice-daily`
+  — a bounded headless run (turn + budget + timeout capped, spend ledgered) at 09:07 and
+  17:07 while the laptop is awake, with merge authority and the same rails
+  (`sdlc/routines/prompts/pr-shepherd.md`). Crontab skips missed slots; it doesn't catch up.
 - Every firing re-reads `state/shepherd.md` first; a PR already `inbox` stays with the human
   until they act — don't re-litigate it every run.

--- a/plugins/core/skills/pr-shepherd/SKILL.md
+++ b/plugins/core/skills/pr-shepherd/SKILL.md
@@ -74,6 +74,11 @@ resumes instead of re-diagnosing. **The agent forgets; the repo does not.**
 ## Schedule
 
 - On demand: `/pr-shepherd`.
-- Interval: `/loop 15m /pr-shepherd` — each firing re-reads state, handles what changed.
+- Interval (session open): `/loop 15m /pr-shepherd` — each firing re-reads state, handles
+  what changed.
+- Unattended cadence (no session open): `compass schedule add pr-shepherd --twice-daily`
+  — a bounded headless run (turn + budget + timeout capped, spend ledgered) at 09:07 and
+  17:07 while the laptop is awake, with merge authority and the same rails
+  (`sdlc/routines/prompts/pr-shepherd.md`). Crontab skips missed slots; it doesn't catch up.
 - Every firing re-reads `state/shepherd.md` first; a PR already `inbox` stays with the human
   until they act — don't re-litigate it every run.

--- a/scripts/compass-schedule.sh
+++ b/scripts/compass-schedule.sh
@@ -279,7 +279,10 @@ cmd_run() {
   local tools="$ALLOWED_TOOLS"
   [ "$routine" = "ci-watch" ] && tools="${ALLOWED_TOOLS}${CI_WATCH_EXTRA_TOOLS}"
   if [ "$routine" = "pr-shepherd" ]; then
-    tools="${ALLOWED_TOOLS}${PR_SHEPHERD_EXTRA_TOOLS}"
+    # Compose WITHOUT the base list's Bash(gh api:*): with merge authority granted,
+    # gh api is an escape hatch to the merge/ref REST endpoints that would defeat
+    # the squash-only enforcement below (audit finding on #83).
+    tools="${ALLOWED_TOOLS/,Bash(gh api:*)/}${PR_SHEPHERD_EXTRA_TOOLS}"
     # Fixing + testing + merging needs more room than a comment-only routine.
     maxturns="${COMPASS_ROUTINE_MAX_TURNS:-60}" budget="${COMPASS_ROUTINE_BUDGET:-3.00}" tmo="${COMPASS_ROUTINE_TIMEOUT:-45m}"
   fi

--- a/scripts/compass-schedule.sh
+++ b/scripts/compass-schedule.sh
@@ -7,7 +7,7 @@
 #   remove <routine>
 #   run <routine> [DIR]
 #
-# Routines: dep-refresh  flaky-triage  doc-freshness  pr-babysit  ci-watch
+# Routines: dep-refresh  flaky-triage  doc-freshness  pr-babysit  ci-watch  pr-shepherd
 #
 # Crontab block is delimited by:
 #   # >>> compass schedule >>>
@@ -30,7 +30,7 @@ BLOCK_CLOSE="# <<< compass schedule <<<"
 # ---------------------------------------------------------------------------
 # Valid routines (space-separated; validated by validate_routine)
 # ---------------------------------------------------------------------------
-VALID_ROUTINES="dep-refresh flaky-triage doc-freshness pr-babysit ci-watch"
+VALID_ROUTINES="dep-refresh flaky-triage doc-freshness pr-babysit ci-watch pr-shepherd"
 
 # Allowed tools for each routine's claude invocation (read + git + build/test only).
 ALLOWED_TOOLS="Read,Grep,Glob,Bash(git log:*),Bash(git diff:*),Bash(git status:*),Bash(git add:*),Bash(git commit:*),Bash(go build:*),Bash(go test:*),Bash(go vet:*),Bash(cargo build:*),Bash(cargo test:*),Bash(npm:*),Bash(pnpm:*),Bash(npx tsc:*),Bash(pytest:*),Bash(ruff:*),Bash(make:*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue comment:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api:*)"
@@ -39,6 +39,12 @@ ALLOWED_TOOLS="Read,Grep,Glob,Bash(git log:*),Bash(git diff:*),Bash(git status:*
 # ponytail: allowedTools can't scope a push to non-default branches; the prompt's hard
 # rules + repo branch protection are the guard on the default branch.
 CI_WATCH_EXTRA_TOOLS=",Edit,Write,Bash(git checkout:*),Bash(git switch:*),Bash(git push:*),Bash(gh pr checkout:*),Bash(gh pr create:*)"
+
+# pr-shepherd is the full-authority scheduled loop: everything ci-watch has, plus
+# worktrees (fix on the PR branch in isolation), check reading, label edits, and —
+# uniquely — merge. Merge safety is layered: the prompt requires all checks green,
+# and the branch ruleset enforces required checks server-side regardless.
+PR_SHEPHERD_EXTRA_TOOLS="${CI_WATCH_EXTRA_TOOLS},Bash(git worktree:*),Bash(gh pr checks:*),Bash(gh pr diff:*),Bash(gh pr edit:*),Bash(gh pr merge --squash:*)"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -54,10 +60,11 @@ Usage:
   compass schedule run <routine> [DIR]
   compass schedule -h|--help
 
-Routines: dep-refresh  flaky-triage  doc-freshness  pr-babysit  ci-watch
+Routines: dep-refresh  flaky-triage  doc-freshness  pr-babysit  ci-watch  pr-shepherd
 
 Schedule flags:
   --daily             0 6 * * *   (daily at 06:00)
+  --twice-daily       7 9,17 * * *  (09:07 + 17:07 — crontab only fires while the laptop is awake; missed slots are skipped, not caught up)
   --weekly            0 6 * * 1   (Mondays at 06:00)  [default]
   --cron "<expr>"     custom 5-field cron expression
 
@@ -167,6 +174,7 @@ cmd_add() {
   while [ $# -gt 0 ]; do
     case "$1" in
       --daily)  cron_expr="0 6 * * *";  shift ;;
+      --twice-daily) cron_expr="7 9,17 * * *"; shift ;;   # off-minute on purpose (thundering-herd kindness)
       --weekly) cron_expr="0 6 * * 1";  shift ;;
       --cron)
         [ $# -ge 2 ] || die "--cron requires an expression argument"
@@ -270,6 +278,11 @@ cmd_run() {
   local tmo="${COMPASS_ROUTINE_TIMEOUT:-30m}" rc=0 out
   local tools="$ALLOWED_TOOLS"
   [ "$routine" = "ci-watch" ] && tools="${ALLOWED_TOOLS}${CI_WATCH_EXTRA_TOOLS}"
+  if [ "$routine" = "pr-shepherd" ]; then
+    tools="${ALLOWED_TOOLS}${PR_SHEPHERD_EXTRA_TOOLS}"
+    # Fixing + testing + merging needs more room than a comment-only routine.
+    maxturns="${COMPASS_ROUTINE_MAX_TURNS:-60}" budget="${COMPASS_ROUTINE_BUDGET:-3.00}" tmo="${COMPASS_ROUTINE_TIMEOUT:-45m}"
+  fi
   out="$(
     cd "$dir" || exit 1
     if command -v timeout >/dev/null 2>&1; then to() { timeout "$tmo" "$@"; }; else to() { "$@"; }; fi

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -258,6 +258,21 @@ echo "compass-schedule — unattended cron run is bounded:"
 if grep -q -- '--max-turns' "$ROOT/scripts/compass-schedule.sh" && grep -q -- '--max-budget-usd' "$ROOT/scripts/compass-schedule.sh"; then
   ok "cron claude -p has turn + budget caps"; else no "cron claude -p is missing turn/budget caps"; fi
 
+echo "compass-schedule — pr-shepherd routine wiring:"
+if grep -q 'VALID_ROUTINES=.*pr-shepherd' "$ROOT/scripts/compass-schedule.sh"; then
+  ok "pr-shepherd is a valid routine"; else no "pr-shepherd missing from VALID_ROUTINES"; fi
+[ -f "$ROOT/sdlc/routines/prompts/pr-shepherd.md" ] && ok "pr-shepherd prompt exists" || no "pr-shepherd prompt missing"
+# every safety rail the prompt promises must actually be in the prompt
+for rail in "Never force-push" "Never merge red" "THREE STRIKES" "READ-ONLY" "no test, no push"; do
+  if grep -q "$rail" "$ROOT/sdlc/routines/prompts/pr-shepherd.md"; then
+    ok "prompt rail present: $rail"; else no "prompt rail missing: $rail"; fi
+done
+if grep -q 'PR_SHEPHERD_EXTRA_TOOLS=' "$ROOT/scripts/compass-schedule.sh" \
+   && grep -q 'gh pr merge --squash:' "$ROOT/scripts/compass-schedule.sh"; then
+  ok "shepherd toolset grants squash-merge (and only squash)"; else no "shepherd toolset missing/over-broad"; fi
+if grep -q -- '--twice-daily' "$ROOT/scripts/compass-schedule.sh"; then
+  ok "--twice-daily cadence flag exists"; else no "--twice-daily flag missing"; fi
+
 echo "new-repo — a dangling AGENTS.md symlink does not abort (set -e):"
 if command -v git >/dev/null 2>&1; then
   NR="$(mktemp -d)"

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -263,7 +263,7 @@ if grep -q 'VALID_ROUTINES=.*pr-shepherd' "$ROOT/scripts/compass-schedule.sh"; t
   ok "pr-shepherd is a valid routine"; else no "pr-shepherd missing from VALID_ROUTINES"; fi
 [ -f "$ROOT/sdlc/routines/prompts/pr-shepherd.md" ] && ok "pr-shepherd prompt exists" || no "pr-shepherd prompt missing"
 # every safety rail the prompt promises must actually be in the prompt
-for rail in "Never force-push" "Never merge red" "THREE STRIKES" "READ-ONLY" "no test, no push"; do
+for rail in "Never force-push" "Never merge red" "THREE STRIKES" "READ-ONLY" "no test, no push" "NEVER MERGE" "same-repo PRs only"; do
   if grep -q "$rail" "$ROOT/sdlc/routines/prompts/pr-shepherd.md"; then
     ok "prompt rail present: $rail"; else no "prompt rail missing: $rail"; fi
 done

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -270,6 +270,22 @@ done
 if grep -q 'PR_SHEPHERD_EXTRA_TOOLS=' "$ROOT/scripts/compass-schedule.sh" \
    && grep -q 'gh pr merge --squash:' "$ROOT/scripts/compass-schedule.sh"; then
   ok "shepherd toolset grants squash-merge (and only squash)"; else no "shepherd toolset missing/over-broad"; fi
+# The composed toolset must strip gh api — with merge authority it's an escape hatch to
+# the merge/ref REST endpoints. Evaluate the ACTUAL composition, not the source text.
+shep_tools="$(bash -c '
+  source /dev/null
+  eval "$(grep -E "^(ALLOWED_TOOLS|CI_WATCH_EXTRA_TOOLS|PR_SHEPHERD_EXTRA_TOOLS)=" "'"$ROOT"'/scripts/compass-schedule.sh")"
+  printf "%s" "${ALLOWED_TOOLS/,Bash(gh api:*)/}${PR_SHEPHERD_EXTRA_TOOLS}"
+')"
+case "$shep_tools" in
+  *"gh api"*) no "shepherd composed toolset still contains gh api (merge escape hatch)" ;;
+  *"gh pr merge --squash"*) ok "shepherd composed toolset: squash-only, no gh api" ;;
+  *) no "shepherd composed toolset lost the squash-merge grant" ;;
+esac
+# The prompt's merge command must be the exact allowlisted prefix form (prefix matching:
+# 'gh pr merge <n> --squash' would be DENIED by 'gh pr merge --squash:*').
+if grep -q 'gh pr merge --squash <n>' "$ROOT/sdlc/routines/prompts/pr-shepherd.md"; then
+  ok "prompt uses the allowlisted flags-first merge form"; else no "prompt merge form won't match the allowlist prefix"; fi
 if grep -q -- '--twice-daily' "$ROOT/scripts/compass-schedule.sh"; then
   ok "--twice-daily cadence flag exists"; else no "--twice-daily flag missing"; fi
 

--- a/sdlc/routines/prompts/pr-shepherd.md
+++ b/sdlc/routines/prompts/pr-shepherd.md
@@ -1,0 +1,37 @@
+You are **PR Shepherd** (a scheduled maintenance agent with MERGE AUTHORITY for this
+run — the repo owner scheduled it; the branch ruleset still enforces required checks
+server-side). Work the compass `pr-shepherd` procedure end-to-end, bounded and terse.
+
+ENUMERATE: `gh pr list --state open --json number,title,author,isDraft,isCrossRepository,headRefName,statusCheckRollup`.
+Skip drafts. Fork PRs (`isCrossRepository` true, or the field missing) are READ-ONLY:
+diagnose + comment, never check out, never push.
+
+PER PR, in ascending number order:
+1. Read `state/shepherd.md` first (create if absent). A PR already marked `inbox` gets at
+   most ONE nudge comment per day — do not re-litigate it.
+2. All checks green → squash-merge it (`gh pr merge <n> --squash`). Done is done.
+3. Red checks → read the failing step's actual log (`gh run view <id> --log-failed`),
+   classify, then act:
+   - environmental (missing secrets, runner flake, quota): note it; if recurring, comment
+     naming the workflow-level root cause. Never "fix" the PR for an environmental red.
+   - mechanical (drift/sync gate, lint, format, lockfile, generated files): fix on the PR
+     branch in a git worktree. Run the SAME gate locally and see it pass BEFORE pushing.
+     Commit message names the gate it satisfies.
+   - real defect (failing tests on changed logic, review findings): fix it PROD-grade —
+     root cause, not symptom; matching tests in the diff (no test, no push); run the
+     repo's test suite locally and see it pass; a short PR comment explaining what was
+     wrong and what the fix does (GA changelog tone, no filler). If the right fix is
+     ambiguous or needs a product decision, do NOT guess: comment the diagnosis with
+     `file:line`, label `sdlc:needs-human`, mark `inbox`.
+4. THREE STRIKES: after 3 failed fix attempts on one PR, stop, mark `inbox` with what was
+   tried. Never force-push. Never merge red. Never bypass a required check. Never close a
+   PR you didn't merge — closing is a human call.
+5. After pushing a fix, re-check once later in the run; if checks are still running at the
+   end, leave a one-line status comment and let the next scheduled run finish the job.
+
+PERSIST: append one row per touched PR to `state/shepherd.md`
+(`| pr | class | action | status |`) and commit that file to the PR branch ONLY if the
+repo tracks it; otherwise leave it as a local working note.
+
+You are on a turn/budget/timeout leash: prefer finishing two PRs completely over
+touching five. Leave nothing half-pushed.

--- a/sdlc/routines/prompts/pr-shepherd.md
+++ b/sdlc/routines/prompts/pr-shepherd.md
@@ -4,7 +4,8 @@ server-side). Work the compass `pr-shepherd` procedure end-to-end, bounded and t
 
 ENUMERATE: `gh pr list --state open --json number,title,author,isDraft,isCrossRepository,headRefName,statusCheckRollup`.
 Skip drafts. Fork PRs (`isCrossRepository` true, or the field missing) are READ-ONLY:
-diagnose + comment, never check out, never push.
+diagnose + comment ONLY — never check out, never push, and NEVER MERGE, even fully green.
+External code always waits for a human; your merge authority covers same-repo PRs only.
 
 PER PR, in ascending number order:
 1. Read `state/shepherd.md` first (create if absent). A PR already marked `inbox` gets at

--- a/sdlc/routines/prompts/pr-shepherd.md
+++ b/sdlc/routines/prompts/pr-shepherd.md
@@ -9,7 +9,7 @@ diagnose + comment, never check out, never push.
 PER PR, in ascending number order:
 1. Read `state/shepherd.md` first (create if absent). A PR already marked `inbox` gets at
    most ONE nudge comment per day — do not re-litigate it.
-2. All checks green → squash-merge it (`gh pr merge <n> --squash`). Done is done.
+2. All checks green → squash-merge it (`gh pr merge --squash <n>` — flags-first is the only allowlisted form). Done is done.
 3. Red checks → read the failing step's actual log (`gh run view <id> --log-failed`),
    classify, then act:
    - environmental (missing secrets, runner flake, quota): note it; if recurring, comment


### PR DESCRIPTION
The feature ask: compass-enabled repos get PRs monitored on a cadence and handled e2e from the laptop's Claude Code, PROD-grade, without a human driving.

- `compass schedule add pr-shepherd --twice-daily` → crontab entry (09:07/17:07, off-minute; skips slots while the laptop sleeps — documented).
- Routine prompt = the pr-shepherd skill with **merge authority granted per scheduled run**: diagnose from logs → environmental/mechanical/real-defect taxonomy → fixes require tests + local gate pass before push → GA-tone PR comment → squash-merge only when ALL checks green (the new branch ruleset enforces this server-side too).
- Hard rails, each asserted by `test-cli.sh`: never force-push, never merge red, 3-strikes → `sdlc:needs-human`, fork PRs read-only, never closes unmerged PRs, only `gh pr merge --squash` in the tool allowlist.
- Bounded: 60 turns / $3 / 45m per run (env-overridable), spend ledgered like every routine.

## Verification
test-cli **140/0** (incl. 9 new wiring/rail assertions) · doctor **143 ok/0** · shellcheck clean · plugin sync in sync
Note: one pre-existing sandbox-backend test was flaky on first local run, passed on both re-runs.