### PR TITLE
docs(brand): README + site + SVG refresh for the v2.0.0 cut

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ git clone https://github.com/dshakes/compass ~/compass && cd ~/compass && ./quic
 
 <div align="center">
 
-Open a PR and compass **reviews it, security-checks it, runs the tests, cross-audits it with a second model — then pushes its own fixes until it's green.** You merge. **☝ That's a real PR** — every event above is inspectable.
+Open a PR and compass **reviews it, security-checks it, runs the tests, cross-audits it with two more models — three cross-model gates (Claude review · Codex audit · Gemini audit) — then pushes its own fixes until it's green.** You merge. **☝ That's a real PR** — every event above is inspectable.
 
 **The idea in one line: the loop is the unit of work.** A one-shot agent stops at its first wrong answer. compass *loops* — **generate → test → critique → fix → repeat against a gate** — so quality comes from iteration, not one lucky prompt. → [how the loop works](docs/09-sdlc.md) · [the thesis](docs/loop-engineering.md)
 
@@ -137,7 +137,7 @@ Opus 4.8 · myrepo · main* · 45k ctx · $1.23 · 🧭 🛡1 🧹2 💡1 📉~$
 
 ## Loops all the way up
 
-Autonomy here isn't one big magic button — it's the *same closed loop* applied at four scales. Each runs until a gate says "done," then stops at a human. That's the whole trick: **iteration under a gate beats a single confident guess.**
+Autonomy here isn't one big magic button — it's the *same closed loop* applied at five scales. Each runs until a gate says "done," then stops at a human. That's the whole trick: **iteration under a gate beats a single confident guess.**
 
 | | Loop | What it drives | Where it stops |
 |---|---|---|---|
@@ -146,6 +146,12 @@ Autonomy here isn't one big magic button — it's the *same closed loop* applied
 | 🩺 | **The CI-fix loop** | any check suite goes red → failure log + auto-fix on the PR; main goes red → one free rerun, then a `ci-fix/*` PR | round cap → a human; never merges |
 | 🛰️ | **The fleet loop** | the whole pipeline, scheduled across *every repo you own*, overnight, test-gated | a PR per repo, **approve from your phone** |
 | 👥 | **The workflow loops** | parallel agents that fan out, fact-check each other, and converge | one synthesized answer |
+
+**The newest turn of the crank — `pr-shepherd`:** every open PR taken end-to-end — diagnose the red check from its log, classify it, fix + verify the mechanical ones, and stop at a merge gate that's **enforced server-side** (required checks + ruleset, not the agent's honor). Run it on demand (`/pr-shepherd`), on an interval (`/loop 15m /pr-shepherd`), or unattended: `compass schedule add pr-shepherd --twice-daily`.
+
+<p align="center">
+  <a href="docs/20-loops.md"><img src="assets/shepherd-loop.svg" alt="The PR shepherd loop: 1 enumerate every open PR (skip drafts, forks stay read-only) → 2 diagnose by reading the failing log, never guessing → 3 classify environmental / mechanical / real defect → 4 fix mechanical failures and pass the gate locally first → 5 push to the PR's own branch (three-strikes cap) → all checks green? → squash-merge (green + session authority; gate enforced server-side by required checks + ruleset) or inbox where a human decides (real defects are never auto-fixed silently — the diagnosis is already written on the PR). State persists in state/shepherd.md and the loop fires twice daily, or on an interval via /loop." width="860"></a>
+</p>
 
 A loop that runs while you sleep is five moves — **discovery → handoff → verification → persistence → scheduling** — and compass ships a primitive for each. It also guards the four costs a loop runs up *silently* (verification debt, comprehension rot, cognitive surrender, token blowout): an independent evaluator that assumes broken and *runs* it, `compass digest` to keep you understanding what merged, the permanent human gate, and per-day + live budget caps. → [the five moves & four guards](docs/20-loops.md) · [the thesis](docs/loop-engineering.md)
 
@@ -210,7 +216,7 @@ Everything below is **on after one install** or a single opt-in — the autonomo
 |---|---|---|---|
 | 🔁 | **Autonomous SDLC** | the review → security → tests → cross-audit → **auto-fix → re-review** loop; you merge | [09-sdlc](docs/09-sdlc.md) |
 | 🩺 | **CI auto-fix** | no CI failure goes unhandled: red PR checks feed the fix loop; red main gets one free rerun, then a `ci-fix/*` PR | [09-sdlc](docs/09-sdlc.md) |
-| 🔄 | **Loop engineering** | the five moves wired up: `morning-triage` discovery · `pr-shepherd` PR handoff → merge gate · an acting/skeptic evaluator · `compass digest` · per-day budget cap | [20-loops](docs/20-loops.md) |
+| 🔄 | **Loop engineering** | the five moves wired up: `morning-triage` discovery · `pr-shepherd` takes every open PR to the merge gate (on demand, `/loop 15m /pr-shepherd`, or `compass schedule add pr-shepherd --twice-daily` unattended) · an acting/skeptic evaluator · `compass digest` · per-day budget cap | [20-loops](docs/20-loops.md) |
 | 🛰️ | **The fleet** | the loop, scheduled across *all* your repos through a test gate; approve from your phone | [14-fleet](docs/14-fleet.md) |
 | 👥 | **The crew + workflows** | cost-tiered expert subagents · slash-commands · dynamic workflows that fact-check each other | [agents roster](docs/agents-roster.md) · [12](docs/12-every-agent.md) · [13](docs/13-workflows.md) |
 | 🛡 | **Guardrails & scanning** | a hook layer that blocks disasters, catches secrets (write-hook + `compass scan`), auto-formats, keeps a JSONL audit log | [16-hardening](docs/16-hardening-and-frontier.md) |

--- a/assets/hardening-frontier.svg
+++ b/assets/hardening-frontier.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 600" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 684" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#0d1117"/><stop offset="1" stop-color="#0a0e14"/></linearGradient>
     <linearGradient id="acc" x1="0" y1="0" x2="1" y2="0">
@@ -17,8 +17,8 @@
       <path d="M0,-8 L7,-5 V1 C7,6 3.5,9 0,10 C-3.5,9 -7,6 -7,1 V-5 Z"/><path d="M-3,0.5 L-0.8,3 L3.4,-2.2"/>
     </g>
   </defs>
-  <rect x="1" y="1" width="1198" height="598" rx="20" fill="url(#bg)" stroke="#30363d" stroke-width="2"/>
-  <rect x="1" y="596" width="1198" height="4" fill="url(#acc)"/>
+  <rect x="1" y="1" width="1198" height="682" rx="20" fill="url(#bg)" stroke="#30363d" stroke-width="2"/>
+  <rect x="1" y="680" width="1198" height="4" fill="url(#acc)"/>
 
   <!-- header -->
   <g transform="translate(52,44)">
@@ -40,7 +40,7 @@
 
   <!-- ===================== BAND 1 · HARDENED CORE (stable) ===================== -->
   <g>
-    <rect x="40" y="84" width="796" height="146" rx="16" fill="#10161d" stroke="#2ea44f" stroke-width="1.8"/>
+    <rect x="40" y="84" width="796" height="230" rx="16" fill="#10161d" stroke="#2ea44f" stroke-width="1.8"/>
     <g color="#3fb950" transform="translate(64,108)"><use href="#ic-shield"/></g>
     <text x="80" y="106" font-size="15" font-weight="800" fill="#f0f6fc">HARDENED CORE</text>
     <text x="80" y="123" font-size="11.5" fill="#7d8590" font-weight="600">stable · gated in CI · footgun-prevention, not a security boundary</text>
@@ -51,7 +51,7 @@
         <text x="145" y="183" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">data-driven guardrail</text>
         <text x="145" y="198" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">sourceable · pure</text></g>
       <g><rect x="246" y="138" width="178" height="74" rx="11" fill="#0d1117" stroke="#3fb950" stroke-width="1.6"/>
-        <text x="335" y="164" text-anchor="middle" font-size="13.5" fill="#e6edf3">61-case corpus</text>
+        <text x="335" y="164" text-anchor="middle" font-size="13.5" fill="#e6edf3">147-case corpus</text>
         <text x="335" y="183" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">must-block / must-allow</text>
         <text x="335" y="198" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">closes every bypass</text></g>
       <g><rect x="436" y="138" width="178" height="74" rx="11" fill="#10231a" stroke="#2ea44f" stroke-width="2.2"/>
@@ -62,74 +62,82 @@
         <text x="723" y="164" text-anchor="middle" font-size="13.5" fill="#e6edf3">actions audit</text>
         <text x="723" y="183" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">drift · least-priv</text>
         <text x="723" y="198" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">SHA-pin · injection</text></g>
+      <g><rect x="56" y="222" width="178" height="74" rx="11" fill="#0d1117" stroke="#3fb950" stroke-width="1.6"/>
+        <text x="145" y="248" text-anchor="middle" font-size="13.5" fill="#e6edf3">3 cross-model gates</text>
+        <text x="145" y="267" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">Claude review · Codex audit</text>
+        <text x="145" y="282" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">· Gemini audit — every PR</text></g>
+      <g><rect x="246" y="222" width="178" height="74" rx="11" fill="#0d1117" stroke="#3fb950" stroke-width="1.6"/>
+        <text x="335" y="248" text-anchor="middle" font-size="13.5" fill="#e6edf3">hard budget ceiling</text>
+        <text x="335" y="267" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">SDLC_BUDGET halts the run</text>
+        <text x="335" y="282" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">each step: min(step, remaining)</text></g>
     </g>
   </g>
 
   <!-- ===================== BAND 2 · FRONTIER (opt-in) ===================== -->
   <g>
-    <rect x="40" y="240" width="796" height="156" rx="16" fill="#13101d" stroke="#8A63D2" stroke-width="1.8" stroke-dasharray="6 4"/>
-    <text x="64" y="264" font-size="15" font-weight="800" fill="#f0f6fc">FRONTIER</text>
-    <text x="178" y="264" font-size="11.5" fill="#7d8590" font-weight="600">opt-in · experimental · honest-labeled</text>
+    <rect x="40" y="324" width="796" height="156" rx="16" fill="#13101d" stroke="#8A63D2" stroke-width="1.8" stroke-dasharray="6 4"/>
+    <text x="64" y="348" font-size="15" font-weight="800" fill="#f0f6fc">FRONTIER</text>
+    <text x="178" y="348" font-size="11.5" fill="#7d8590" font-weight="600">opt-in · experimental · honest-labeled</text>
     <g font-weight="700" font-size="12.5" fill="#e6edf3">
       <!-- row 1 -->
-      <g><rect x="56" y="276" width="246" height="50" rx="10" fill="#0d1117" stroke="#a371f7" stroke-width="1.5"/>
-        <text x="70" y="300" font-size="13" fill="#f0f6fc">persistent memory</text>
-        <text x="70" y="316" font-size="10.5" fill="#8b949e" font-weight="600">persists across sessions and repos</text></g>
-      <g><rect x="312" y="276" width="246" height="50" rx="10" fill="#0d1117" stroke="#a371f7" stroke-width="1.5"/>
-        <text x="326" y="300" font-size="13" fill="#f0f6fc">parallel SDLC</text>
-        <text x="326" y="316" font-size="10.5" fill="#8b949e" font-weight="600">+ test-impact QA · diff-size routing</text></g>
-      <g><rect x="568" y="276" width="252" height="50" rx="10" fill="#0d1117" stroke="#a371f7" stroke-width="1.5"/>
-        <text x="582" y="300" font-size="13" fill="#f0f6fc">fleet brain</text>
-        <text x="582" y="316" font-size="10.5" fill="#8b949e" font-weight="600">recurring findings → proposed rules</text></g>
+      <g><rect x="56" y="360" width="246" height="50" rx="10" fill="#0d1117" stroke="#a371f7" stroke-width="1.5"/>
+        <text x="70" y="384" font-size="13" fill="#f0f6fc">persistent memory</text>
+        <text x="70" y="400" font-size="10.5" fill="#8b949e" font-weight="600">persists across sessions and repos</text></g>
+      <g><rect x="312" y="360" width="246" height="50" rx="10" fill="#0d1117" stroke="#a371f7" stroke-width="1.5"/>
+        <text x="326" y="384" font-size="13" fill="#f0f6fc">parallel SDLC</text>
+        <text x="326" y="400" font-size="10.5" fill="#8b949e" font-weight="600">+ test-impact QA · diff-size routing</text></g>
+      <g><rect x="568" y="360" width="252" height="50" rx="10" fill="#0d1117" stroke="#a371f7" stroke-width="1.5"/>
+        <text x="582" y="384" font-size="13" fill="#f0f6fc">fleet brain</text>
+        <text x="582" y="400" font-size="10.5" fill="#8b949e" font-weight="600">recurring findings → proposed rules</text></g>
       <!-- row 2 -->
-      <g><rect x="56" y="332" width="246" height="50" rx="10" fill="#0d1117" stroke="#a371f7" stroke-width="1.5"/>
-        <text x="70" y="356" font-size="13" fill="#f0f6fc">cost-aware router</text>
-        <text x="70" y="372" font-size="10.5" fill="#8b949e" font-weight="600">confidence + budget bias (floor kept)</text></g>
-      <g><rect x="312" y="332" width="246" height="50" rx="10" fill="#0d1117" stroke="#a371f7" stroke-width="1.5"/>
-        <text x="326" y="356" font-size="13" fill="#f0f6fc">spec-kit interop</text>
-        <text x="326" y="372" font-size="10.5" fill="#8b949e" font-weight="600">governance UNDER spec-driven dev</text></g>
-      <g><rect x="568" y="332" width="252" height="50" rx="10" fill="#0d1117" stroke="#a371f7" stroke-width="1.5"/>
-        <text x="582" y="356" font-size="13" fill="#f0f6fc">SBOM + signed commits</text>
-        <text x="582" y="372" font-size="10.5" fill="#8b949e" font-weight="600">provenance on every agent PR</text></g>
+      <g><rect x="56" y="416" width="246" height="50" rx="10" fill="#0d1117" stroke="#a371f7" stroke-width="1.5"/>
+        <text x="70" y="440" font-size="13" fill="#f0f6fc">cost-aware router</text>
+        <text x="70" y="456" font-size="10.5" fill="#8b949e" font-weight="600">confidence + budget bias (floor kept)</text></g>
+      <g><rect x="312" y="416" width="246" height="50" rx="10" fill="#0d1117" stroke="#a371f7" stroke-width="1.5"/>
+        <text x="326" y="440" font-size="13" fill="#f0f6fc">spec-kit interop</text>
+        <text x="326" y="456" font-size="10.5" fill="#8b949e" font-weight="600">governance UNDER spec-driven dev</text></g>
+      <g><rect x="568" y="416" width="252" height="50" rx="10" fill="#0d1117" stroke="#a371f7" stroke-width="1.5"/>
+        <text x="582" y="440" font-size="13" fill="#f0f6fc">SBOM + signed commits</text>
+        <text x="582" y="456" font-size="10.5" fill="#8b949e" font-weight="600">provenance on every agent PR</text></g>
     </g>
   </g>
 
   <!-- ===================== BAND 3 · CONTROL SURFACE ===================== -->
   <g>
-    <rect x="40" y="406" width="796" height="110" rx="16" fill="#0f1822" stroke="#58a6ff" stroke-width="1.8"/>
-    <text x="64" y="430" font-size="15" font-weight="800" fill="#f0f6fc">CONTROL SURFACE</text>
-    <text x="250" y="430" font-size="11.5" fill="#7d8590" font-weight="600">zero-infra · read-only · no upload</text>
+    <rect x="40" y="490" width="796" height="110" rx="16" fill="#0f1822" stroke="#58a6ff" stroke-width="1.8"/>
+    <text x="64" y="514" font-size="15" font-weight="800" fill="#f0f6fc">CONTROL SURFACE</text>
+    <text x="250" y="514" font-size="11.5" fill="#7d8590" font-weight="600">zero-infra · read-only · no upload</text>
     <g font-weight="700">
-      <g><rect x="56" y="442" width="380" height="58" rx="11" fill="#0d1117" stroke="#58a6ff" stroke-width="1.6"/>
-        <text x="246" y="468" text-anchor="middle" font-size="13.5" fill="#f0f6fc">compass dashboard</text>
-        <text x="246" y="487" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">impact · spend · live fleet PRs in one panel</text></g>
-      <g><rect x="448" y="442" width="372" height="58" rx="11" fill="#0d1117" stroke="#58a6ff" stroke-width="1.6"/>
-        <text x="634" y="468" text-anchor="middle" font-size="13.5" fill="#f0f6fc">--html / --json</text>
-        <text x="634" y="487" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">a shareable page · or feed your own tools</text></g>
+      <g><rect x="56" y="526" width="380" height="58" rx="11" fill="#0d1117" stroke="#58a6ff" stroke-width="1.6"/>
+        <text x="246" y="552" text-anchor="middle" font-size="13.5" fill="#f0f6fc">compass dashboard</text>
+        <text x="246" y="571" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">impact · spend · live fleet PRs in one panel</text></g>
+      <g><rect x="448" y="526" width="372" height="58" rx="11" fill="#0d1117" stroke="#58a6ff" stroke-width="1.6"/>
+        <text x="634" y="552" text-anchor="middle" font-size="13.5" fill="#f0f6fc">--html / --json</text>
+        <text x="634" y="571" text-anchor="middle" font-size="10.5" fill="#8b949e" font-weight="600">a shareable page · or feed your own tools</text></g>
     </g>
   </g>
 
   <!-- ===================== arrows into the human merge gate ===================== -->
-  <line x1="836" y1="157" x2="868" y2="240" stroke="#8b949e" stroke-width="2.2" marker-end="url(#ar)"/>
-  <line x1="836" y1="318" x2="868" y2="305" stroke="#8b949e" stroke-width="2.2" marker-end="url(#ar)"/>
-  <line x1="836" y1="461" x2="868" y2="372" stroke="#8b949e" stroke-width="2.2" marker-end="url(#ar)"/>
-  <circle r="3.4" fill="#3fb950" filter="url(#g)"><animateMotion path="M836,318 L866,306" dur="1.5s" begin="1.6s" repeatCount="indefinite"/></circle>
+  <line x1="836" y1="199" x2="868" y2="272" stroke="#8b949e" stroke-width="2.2" marker-end="url(#ar)"/>
+  <line x1="836" y1="402" x2="868" y2="388" stroke="#8b949e" stroke-width="2.2" marker-end="url(#ar)"/>
+  <line x1="836" y1="545" x2="868" y2="470" stroke="#8b949e" stroke-width="2.2" marker-end="url(#ar)"/>
+  <circle r="3.4" fill="#3fb950" filter="url(#g)"><animateMotion path="M836,402 L866,389" dur="1.5s" begin="1.6s" repeatCount="indefinite"/></circle>
 
   <!-- ===================== HUMAN MERGE GATE (the spine, unmoved) ===================== -->
   <g>
-    <rect x="872" y="84" width="286" height="432" rx="16" fill="#10241a" stroke="#2ea44f" stroke-width="2.6"/>
-    <g color="#58a6ff" transform="translate(1015,200) scale(2.6)"><use href="#ic-human"/></g>
-    <text x="1015" y="290" text-anchor="middle" font-size="20" font-weight="800" fill="#3fb950">HUMAN</text>
-    <text x="1015" y="316" text-anchor="middle" font-size="20" font-weight="800" fill="#3fb950">MERGE GATE</text>
-    <text x="1015" y="344" text-anchor="middle" font-size="13" fill="#7ee2a8" font-weight="700">unmoved · by design</text>
-    <line x1="912" y1="364" x2="1118" y2="364" stroke="#1f3b2a" stroke-width="1.5"/>
-    <text x="1015" y="392" text-anchor="middle" font-size="12.5" fill="#adbac7">agents prepare —</text>
-    <text x="1015" y="412" text-anchor="middle" font-size="13.5" fill="#e6edf3" font-weight="800">you always merge &amp; deploy</text>
-    <text x="1015" y="446" text-anchor="middle" font-size="11" fill="#6e7681">readable config · reversible install</text>
-    <text x="1015" y="464" text-anchor="middle" font-size="11" fill="#6e7681">nothing here moves the spine</text>
+    <rect x="872" y="84" width="286" height="516" rx="16" fill="#10241a" stroke="#2ea44f" stroke-width="2.6"/>
+    <g color="#58a6ff" transform="translate(1015,242) scale(2.6)"><use href="#ic-human"/></g>
+    <text x="1015" y="332" text-anchor="middle" font-size="20" font-weight="800" fill="#3fb950">HUMAN</text>
+    <text x="1015" y="358" text-anchor="middle" font-size="20" font-weight="800" fill="#3fb950">MERGE GATE</text>
+    <text x="1015" y="386" text-anchor="middle" font-size="13" fill="#7ee2a8" font-weight="700">unmoved · by design</text>
+    <line x1="912" y1="406" x2="1118" y2="406" stroke="#1f3b2a" stroke-width="1.5"/>
+    <text x="1015" y="434" text-anchor="middle" font-size="12.5" fill="#adbac7">agents prepare —</text>
+    <text x="1015" y="454" text-anchor="middle" font-size="13.5" fill="#e6edf3" font-weight="800">you always merge &amp; deploy</text>
+    <text x="1015" y="488" text-anchor="middle" font-size="11" fill="#6e7681">readable config · reversible install</text>
+    <text x="1015" y="506" text-anchor="middle" font-size="11" fill="#6e7681">nothing here moves the spine</text>
   </g>
 
 
   <!-- footer tagline -->
-  <text x="438" y="556" text-anchor="middle" font-size="12.5" fill="#8b949e">harden trust  ·  let the config <tspan fill="#a371f7" font-weight="700">learn</tspan>  ·  make it <tspan fill="#58a6ff" font-weight="700">cheaper &amp; visible</tspan>  ·  <tspan fill="#3fb950" font-weight="700">you still merge</tspan></text>
+  <text x="438" y="640" text-anchor="middle" font-size="12.5" fill="#8b949e">harden trust  ·  let the config <tspan fill="#a371f7" font-weight="700">learn</tspan>  ·  make it <tspan fill="#58a6ff" font-weight="700">cheaper &amp; visible</tspan>  ·  <tspan fill="#3fb950" font-weight="700">you still merge</tspan></text>
 </svg>

--- a/assets/shepherd-loop.svg
+++ b/assets/shepherd-loop.svg
@@ -1,0 +1,135 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 620" role="img" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>The PR shepherd loop — enumerate open PRs, diagnose failing checks from their logs, classify environmental / mechanical / real defect, fix and verify locally, push, then squash-merge when every check is green (a gate enforced server-side) or hand real defects to the human inbox; state persists in state/shepherd.md and the loop fires twice daily.</title>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0d1117"/>
+      <stop offset="1" stop-color="#0a0e14"/>
+    </linearGradient>
+    <linearGradient id="acc" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0"   stop-color="#cf222e"/>
+      <stop offset="0.5" stop-color="#8A63D2"/>
+      <stop offset="1"   stop-color="#2ea44f"/>
+      <animateTransform attributeName="gradientTransform" type="translate" values="-0.3 0;0.3 0;-0.3 0" dur="6s" repeatCount="indefinite"/>
+    </linearGradient>
+    <marker id="ar"  viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#8b949e"/></marker>
+    <marker id="arp" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#8A63D2"/></marker>
+    <marker id="arg" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#2ea44f"/></marker>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#f0596b"/></marker>
+    <filter id="g" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <g id="ic-human" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="0" cy="-4.4" r="3"/><path d="M-5.6,7.4 C-5.6,1.2 5.6,1.2 5.6,7.4"/>
+    </g>
+  </defs>
+
+  <rect x="1" y="1" width="1198" height="618" rx="20" fill="url(#bg)" stroke="#30363d" stroke-width="2"/>
+  <rect x="1" y="616" width="1198" height="4" fill="url(#acc)"/>
+
+  <!-- header -->
+  <g transform="translate(56,46)">
+    <circle r="20" fill="#161b22" stroke="#8A63D2" stroke-width="2.5"/>
+    <g>
+      <path d="M0,-12 A12,12 0 1 1 -10.4,6" fill="none" stroke="#58a6ff" stroke-width="3" stroke-linecap="round"/>
+      <polygon points="-13,2 -7,9 -16,11" fill="#58a6ff"/>
+      <animateTransform attributeName="transform" type="rotate" from="0" to="360" dur="4s" repeatCount="indefinite"/>
+    </g>
+    <text x="36" y="2"  font-size="25" font-weight="800" fill="#f0f6fc">The PR shepherd loop</text>
+    <text x="37" y="22" font-size="14" fill="#8b949e">every open PR → merged or inbox · no PR sits red waiting for a human to read a log</text>
+  </g>
+
+  <!-- ============ the five shepherd steps (left → right) ============ -->
+  <!-- 1 · Enumerate -->
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="0.2s" dur="0.6s" fill="freeze"/>
+    <rect x="62" y="132" width="195" height="84" rx="13" fill="#161b22" stroke="#8A63D2" stroke-width="2"/>
+    <text x="159" y="160" text-anchor="middle" font-size="14" font-weight="800" fill="#a371f7">1 · Enumerate</text>
+    <text x="159" y="181" text-anchor="middle" font-size="10.5" fill="#8b949e">every open PR · skip drafts</text>
+    <text x="159" y="201" text-anchor="middle" font-size="11" font-weight="700" fill="#adbac7">forks stay read-only</text>
+  </g>
+  <!-- 2 · Diagnose -->
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="0.45s" dur="0.6s" fill="freeze"/>
+    <rect x="293" y="132" width="195" height="84" rx="13" fill="#161b22" stroke="#e3b341" stroke-width="2"/>
+    <text x="390" y="160" text-anchor="middle" font-size="14" font-weight="800" fill="#e3b341">2 · Diagnose</text>
+    <text x="390" y="181" text-anchor="middle" font-size="10.5" fill="#8b949e">read the failing log, don't guess</text>
+    <text x="390" y="201" text-anchor="middle" font-size="11" font-weight="700" fill="#adbac7">gh run view --log-failed</text>
+  </g>
+  <!-- 3 · Classify (the judgment step) -->
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="0.7s" dur="0.6s" fill="freeze"/>
+    <rect x="524" y="132" width="195" height="84" rx="13" fill="#161b22" stroke="#58a6ff" stroke-width="2"/>
+    <text x="621" y="160" text-anchor="middle" font-size="14" font-weight="800" fill="#58a6ff">3 · Classify</text>
+    <text x="621" y="181" text-anchor="middle" font-size="10.5" fill="#8b949e">the judgment step</text>
+    <text x="621" y="201" text-anchor="middle" font-size="11" font-weight="700" fill="#adbac7">env · mechanical · defect</text>
+  </g>
+  <!-- 4 · Fix + test (red until the gate passes locally) -->
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="0.95s" dur="0.6s" fill="freeze"/>
+    <rect x="755" y="132" width="195" height="84" rx="13" fill="#161b22" stroke="#cf222e" stroke-width="2.4" filter="url(#g)">
+      <animate attributeName="stroke" values="#cf222e;#cf222e;#2ea44f;#2ea44f;#cf222e" keyTimes="0;0.4;0.5;0.9;1" dur="5s" repeatCount="indefinite"/>
+    </rect>
+    <text x="852" y="160" text-anchor="middle" font-size="14" font-weight="800" fill="#f0f6fc">4 · Fix + test</text>
+    <text x="852" y="181" text-anchor="middle" font-size="10.5" fill="#8b949e">mechanical failures only</text>
+    <text x="852" y="201" text-anchor="middle" font-size="11" font-weight="700" fill="#adbac7">gate passes locally first</text>
+  </g>
+  <!-- 5 · Push -->
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="1.2s" dur="0.6s" fill="freeze"/>
+    <rect x="986" y="132" width="195" height="84" rx="13" fill="#161b22" stroke="#2ea44f" stroke-width="2"/>
+    <text x="1083" y="160" text-anchor="middle" font-size="14" font-weight="800" fill="#3fb950">5 · Push</text>
+    <text x="1083" y="181" text-anchor="middle" font-size="10.5" fill="#8b949e">to the PR's own branch</text>
+    <text x="1083" y="201" text-anchor="middle" font-size="11" font-weight="700" fill="#adbac7">three-strikes cap</text>
+  </g>
+
+  <!-- inter-box arrows + flowing tokens -->
+  <line x1="257" y1="174" x2="291" y2="174" stroke="#8b949e" stroke-width="2.5" marker-end="url(#ar)"/>
+  <line x1="488" y1="174" x2="522" y2="174" stroke="#8b949e" stroke-width="2.5" marker-end="url(#ar)"/>
+  <line x1="719" y1="174" x2="753" y2="174" stroke="#8b949e" stroke-width="2.5" marker-end="url(#ar)"/>
+  <line x1="950" y1="174" x2="984" y2="174" stroke="#8b949e" stroke-width="2.5" marker-end="url(#ar)"/>
+  <circle r="3" fill="#a371f7" filter="url(#g)"><animateMotion path="M257,174 L289,174" dur="1.5s" repeatCount="indefinite"/></circle>
+  <circle r="3" fill="#e3b341" filter="url(#g)"><animateMotion path="M488,174 L520,174" dur="1.5s" begin="0.3s" repeatCount="indefinite"/></circle>
+  <circle r="3" fill="#58a6ff" filter="url(#g)"><animateMotion path="M719,174 L751,174" dur="1.5s" begin="0.6s" repeatCount="indefinite"/></circle>
+  <circle r="3" fill="#f0596b" filter="url(#g)"><animateMotion path="M950,174 L982,174" dur="1.5s" begin="0.9s" repeatCount="indefinite"/></circle>
+
+  <!-- ===== the gate question: all checks green? ===== -->
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="1.5s" dur="0.6s" fill="freeze"/>
+    <path d="M1083,216 C1083,252 800,272 706,272" fill="none" stroke="#8b949e" stroke-width="2.2" marker-end="url(#ar)"/>
+    <rect x="498" y="244" width="204" height="56" rx="12" fill="#161b22" stroke="#e3b341" stroke-width="2"/>
+    <text x="600" y="268" text-anchor="middle" font-size="13.5" font-weight="800" fill="#e3b341">all checks green?</text>
+    <text x="600" y="286" text-anchor="middle" font-size="10.5" fill="#8b949e">environmental reds named, not ignored</text>
+  </g>
+
+  <!-- ===== the two outcomes ===== -->
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="1.8s" dur="0.6s" fill="freeze"/>
+    <path d="M498,272 C420,272 340,300 312,338" fill="none" stroke="#2ea44f" stroke-width="2.2" marker-end="url(#arg)"/>
+    <text x="376" y="298" text-anchor="middle" font-size="11" font-weight="700" fill="#3fb950">green + session authority</text>
+    <rect x="156" y="340" width="310" height="80" rx="13" fill="#13261a" stroke="#2ea44f" stroke-width="2.2"/>
+    <text x="311" y="364" text-anchor="middle" font-size="13.5" font-weight="800" fill="#3fb950">✓ squash-merge</text>
+    <text x="311" y="383" text-anchor="middle" font-size="10.5" fill="#adbac7">never force-push · never merge red</text>
+    <text x="311" y="401" text-anchor="middle" font-size="10.5" font-weight="700" fill="#7ee2a8">gate enforced server-side — required checks + ruleset</text>
+  </g>
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="1.8s" dur="0.6s" fill="freeze"/>
+    <path d="M600,300 C640,322 780,318 850,338" fill="none" stroke="#cf222e" stroke-width="2.2" marker-end="url(#arr)"/>
+    <text x="742" y="312" text-anchor="middle" font-size="11" font-weight="700" fill="#f0596b">real defect · or 3 strikes</text>
+    <rect x="744" y="340" width="310" height="80" rx="13" fill="#161b22" stroke="#cf222e" stroke-width="2.2"/>
+    <g color="#58a6ff" transform="translate(776,378)"><use href="#ic-human" x="0" y="0"/></g>
+    <text x="899" y="364" text-anchor="middle" font-size="13.5" font-weight="800" fill="#f0596b">✉ inbox — a human decides</text>
+    <text x="899" y="383" text-anchor="middle" font-size="10.5" fill="#adbac7">real defects are never auto-fixed silently</text>
+    <text x="899" y="401" text-anchor="middle" font-size="10.5" fill="#8b949e">the diagnosis is already written on the PR</text>
+  </g>
+  <circle r="3.5" fill="#3fb950" filter="url(#g)"><animateMotion path="M498,272 C420,272 340,300 312,338" dur="1.8s" begin="2s" repeatCount="indefinite"/></circle>
+  <circle r="3.5" fill="#f0596b" filter="url(#g)"><animateMotion path="M600,300 C640,322 780,318 850,338" dur="1.8s" begin="2.4s" repeatCount="indefinite"/></circle>
+
+  <!-- ===== persistence + the twice-daily loop-back ===== -->
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="2.1s" dur="0.6s" fill="freeze"/>
+    <path d="M311,420 V438" fill="none" stroke="#6e7681" stroke-width="1.6" stroke-dasharray="4 3"/>
+    <path d="M899,420 V438" fill="none" stroke="#6e7681" stroke-width="1.6" stroke-dasharray="4 3"/>
+    <text x="605" y="452" text-anchor="middle" font-size="11.5" fill="#8b949e">state/shepherd.md — every touched PR logged; the next firing resumes instead of re-diagnosing</text>
+    <path d="M600,458 V466" fill="none" stroke="#6e7681" stroke-width="2" marker-end="url(#ar)"/>
+    <rect x="330" y="468" width="540" height="46" rx="11" fill="#161b22" stroke="#8A63D2" stroke-width="1.8"/>
+    <text x="600" y="487" text-anchor="middle" font-size="12" font-weight="700" fill="#a371f7">↻ it runs unattended — twice daily</text>
+    <text x="600" y="504" text-anchor="middle" font-size="10.5" fill="#adbac7">compass schedule add pr-shepherd --twice-daily · or on an interval: /loop 15m /pr-shepherd</text>
+    <path d="M330,491 C 90,491 52,300 159,218"
+          fill="none" stroke="#8A63D2" stroke-width="2.4" stroke-dasharray="8 6" marker-end="url(#arp)">
+      <animate attributeName="stroke-dashoffset" from="56" to="0" dur="1.1s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <circle r="3.5" fill="#a371f7" filter="url(#g)"><animateMotion path="M330,491 C 90,491 52,300 159,218" dur="3.2s" repeatCount="indefinite"/></circle>
+
+  <!-- footer -->
+  <text x="600" y="586" text-anchor="middle" font-size="13" fill="#8b949e">enumerate → diagnose → classify → <tspan fill="#f0596b" font-weight="700">fix + verify</tspan> → push → green? → <tspan fill="#3fb950" font-weight="700">merge</tspan> | <tspan fill="#f0596b" font-weight="700">inbox</tspan> — and <tspan fill="#3fb950" font-weight="700">the merge stays yours</tspan></text>
+</svg>

--- a/docs/16-hardening-and-frontier.md
+++ b/docs/16-hardening-and-frontier.md
@@ -11,7 +11,7 @@ changes the product's spine — readable config, reversible install, you always 
 > are opt-in and labeled experimental in the same honest spirit as the rest of the repo.
 
 <p align="center">
-  <img src="../assets/hardening-frontier.svg" alt="The hardening + frontier layer in three bands flowing to an unmoved human merge gate. HARDENED CORE (stable, CI-gated): policy.sh data-driven guardrail · 61-case bypass corpus · compass bench (100% precision/recall, router 96.9%) · actions audit (drift, least-privilege, SHA-pinning, injection). FRONTIER (opt-in): persistent memory · parallel SDLC + test-impact + diff-size routing · fleet brain (recurring findings to proposed rules) · cost-aware router · spec-driven interop · SBOM + signed commits. CONTROL SURFACE: compass dashboard (impact, spend, live fleet PRs) · --html/--json. Everything flows to the HUMAN MERGE GATE — unmoved by design; you always merge and deploy." width="900">
+  <img src="../assets/hardening-frontier.svg" alt="The hardening + frontier layer in three bands flowing to an unmoved human merge gate. HARDENED CORE (stable, CI-gated): policy.sh data-driven guardrail · 147-case bypass corpus · compass bench (100% precision/recall, router 96.9%) · actions audit (drift, least-privilege, SHA-pinning, injection) · 3 cross-model gates (Claude review, Codex audit, Gemini audit on every PR) · hard budget ceiling (SDLC_BUDGET halts the run; each step capped at min of step and remaining). FRONTIER (opt-in): persistent memory · parallel SDLC + test-impact + diff-size routing · fleet brain (recurring findings to proposed rules) · cost-aware router · spec-driven interop · SBOM + signed commits. CONTROL SURFACE: compass dashboard (impact, spend, live fleet PRs) · --html/--json. Everything flows to the HUMAN MERGE GATE — unmoved by design; you always merge and deploy." width="900">
 </p>
 
 <p align="center"><sub>↑ the hardening + frontier layer. Below, the same layer as a text diagram:</sub></p>
@@ -20,7 +20,7 @@ changes the product's spine — readable config, reversible install, you always 
 flowchart TB
   subgraph HARDEN["🛡️ Hardened core — stable, CI-gated"]
     pol["policy.sh<br/>data-driven guardrail<br/>(sourceable, pure)"]
-    corp["61-case bypass corpus<br/>+ benchmark<br/>100% precision / recall"]
+    corp["147-case bypass corpus<br/>+ benchmark<br/>100% precision / recall"]
     act["check-actions.sh<br/>drift · least-priv · pinning · injection"]
     pol --> corp
   end

--- a/docs/content.js
+++ b/docs/content.js
@@ -237,6 +237,8 @@ Keep discovery and judgment in the model; keep persistence, de-dup, and the hard
 
 <div class="cal"><span class="h">A loop that needs no schedule</span> <b>CI auto-fix</b> turns the moment a check suite goes red: PR failures feed the round-capped fix loop; a red default branch gets one free rerun, then a <code>ci-fix/*</code> PR. Local form: <code>compass schedule add ci-watch --daily</code>. Details in <a href="#09-sdlc">Autonomous SDLC</a>.</div>
 
+<div class="cal tip"><span class="h">The PR loop, end-to-end</span> <b>pr-shepherd</b> takes every open PR to one of three outcomes — merged, ready-to-merge, or inbox: diagnose the red check from its log, classify (environmental · mechanical · real defect), fix + verify the mechanical ones, and stop at a merge gate <em>enforced server-side</em> (required checks + ruleset). On demand (<code>/pr-shepherd</code>), on an interval (<code>/loop 15m /pr-shepherd</code>), or unattended: <code>compass schedule add pr-shepherd --twice-daily</code>.</div>
+
 > The why behind each move: [Loop engineering](#loop-engineering).`,
 
 "09-sdlc": `# Autonomous SDLC
@@ -249,7 +251,7 @@ Keep discovery and judgment in the model; keep persistence, de-dup, and the hard
 
 \`\`\`
 issue → Planner → Builder → [PR] → Reviewer ⇄ Builder (auto-fix loop)
-                                    Auditor  (Codex — independent second opinion)
+                                    Auditors (Codex + Gemini — independent cross-model opinions)
                                     Security (every push)
                                     QA       (tests)
                                             ↓
@@ -259,11 +261,13 @@ issue → Planner → Builder → [PR] → Reviewer ⇄ Builder (auto-fix loop)
 ## Why it's trustworthy
 
 <div class="feats">
-<div class="feat"><span class="e">👥</span><b>Maker ≠ checker</b><span>Claude builds; a second tool (Codex) audits. An independent opinion, not the author grading itself.</span></div>
+<div class="feat"><span class="e">👥</span><b>Maker ≠ checker</b><span>Claude builds; Codex and Gemini audit — three cross-model gates on every PR, not the author grading itself.</span></div>
 <div class="feat"><span class="e">🔁</span><b>Round-capped auto-fix</b><span>The reviewer's <em>Blocking</em> findings are fixed and re-reviewed up to a few rounds, then handed to a human if still red.</span></div>
 <div class="feat"><span class="e">🩺</span><b>CI auto-fix</b><span>No CI failure goes unhandled: a red check suite feeds the same fix loop on the PR; a red default branch gets one free rerun, then a budget-capped <code>ci-fix/*</code> PR. Disable with <code>SDLC_CI_FIX=off</code>.</span></div>
 <div class="feat"><span class="e">🧾</span><b>Auditable handoffs</b><span>Agents coordinate through the PR (labels + comments) and a shared run-dir — every step is a reviewable artifact.</span></div>
 <div class="feat"><span class="e">🚦</span><b>Gated at every push</b><span>Security and tests run on every push; nothing advances on red.</span></div>
+<div class="feat"><span class="e">💸</span><b>A hard budget ceiling</b><span><code>SDLC_BUDGET</code> halts the run at the cumulative cap (exit 3); each step is capped at min(step, remaining) so the last step can't overshoot.</span></div>
+<div class="feat"><span class="e">🧫</span><b>Inter-step quarantine</b><span>Every step's output passes the red-team detectors before feeding the next — the loop's <em>inputs</em> are scanned, not just its config.</span></div>
 </div>
 
 <div class="cal"><span class="h">Run it</span> <code>/sdlc "&lt;task&gt;"</code> runs the whole pipeline on a branch and opens a PR for you to review. It never presses merge.</div>`,

--- a/docs/index.html
+++ b/docs/index.html
@@ -464,7 +464,7 @@
       </div>
       <div class="scard ok rv"><span class="tag">YOU MERGE</span>
         <div class="ic">🔏</div><h3>Merging unverified code</h3>
-        <p>It reviews, security-checks, tests, cross-audits with a second model, and <b style="color:var(--text)">pushes its own fixes until green</b>. The one thing it never does: press merge. That gate is yours, permanently.</p>
+        <p>It reviews, security-checks, tests, and cross-audits with <b style="color:var(--text)">three cross-model gates</b> — Claude review, Codex audit, Gemini audit — then <b style="color:var(--text)">pushes its own fixes until green</b>. The one thing it never does: press merge. That gate is yours, permanently.</p>
       </div>
     </div>
   </div>
@@ -615,10 +615,11 @@
         </svg>
       </a>
       <div class="rv">
-        <p style="color:var(--muted);margin-bottom:6px;font-size:15px">The same closed loop runs at <b style="color:var(--text)">four scales</b> — each until a gate says done, then it stops at a human:</p>
+        <p style="color:var(--muted);margin-bottom:6px;font-size:15px">The same closed loop runs at <b style="color:var(--text)">five scales</b> — each until a gate says done, then it stops at a human:</p>
         <div class="scales">
           <div class="scale"><span class="em">🔁</span><div><h4>The task loop</h4><p>generate → test → critique → fix — one change driven to green.<span class="stop">stops when tests + review pass</span></div></div>
           <div class="scale"><span class="em">🔎</span><div><h4>The review loop</h4><p>review → auto-fix the Blocking findings → re-review, round-capped ×3.<span class="stop">hands to a human if still red</span></div></div>
+          <div class="scale"><span class="em">🐑</span><div><h4>The PR-shepherd loop</h4><p>every open PR diagnosed from its logs, mechanical fixes verified then pushed — on demand or twice daily, unattended.<span class="stop">stops at the server-enforced merge gate</span></div></div>
           <div class="scale"><span class="em">🛰️</span><div><h4>The fleet loop</h4><p>the whole pipeline, scheduled across every repo you own, overnight, test-gated.<span class="stop">a PR per repo — approve from your phone</span></div></div>
           <div class="scale"><span class="em">👥</span><div><h4>The workflow loops</h4><p>parallel agents that fan out, fact-check each other, and converge.<span class="stop">one synthesized answer</span></div></div>
         </div>
@@ -636,7 +637,7 @@
       <p class="lead">The whole toolkit — guardrails, the crew, the router, the CLI — is live the moment you install. The autonomous loops sit on top, opt-in.</p>
     </div>
     <div class="bento">
-      <div class="fcard span-3 rv"><span class="em">🔁</span><h3>Autonomous SDLC</h3><p>The review → security → tests → cross-audit → auto-fix → re-review loop on every PR. Parallel reviewers, round-capped fixes, a second-model audit — then it stops at your merge.</p><a class="more" href="docs.html#09-sdlc">09-sdlc →</a></div>
+      <div class="fcard span-3 rv"><span class="em">🔁</span><h3>Autonomous SDLC</h3><p>The review → security → tests → cross-audit → auto-fix → re-review loop on every PR. Parallel reviewers, round-capped fixes, three cross-model gates (Claude review · Codex audit · Gemini audit), a hard <code>SDLC_BUDGET</code> ceiling — then it stops at your merge.</p><a class="more" href="docs.html#09-sdlc">09-sdlc →</a></div>
       <div class="fcard span-3 rv"><span class="em">🛰️</span><h3>The fleet</h3><p>The loop, scheduled across all your repos through a test gate — overnight. Wake up to a PR per repo you can approve from your phone.</p><a class="more" href="docs.html#14-fleet">14-fleet →</a></div>
       <div class="fcard span-2 rv"><span class="em">🛡</span><h3>Guardrails &amp; scanning</h3><p>A hook layer that blocks disasters, catches secrets, auto-formats, and keeps a JSONL audit log.</p><a class="more" href="docs.html#16-hardening-and-frontier">16-hardening →</a></div>
       <div class="fcard span-2 rv"><span class="em">🧪</span><h3>Red-team hardening</h3><p>Eval-gated defense vs prompt-injection, config poisoning, safety-override, MCP tool-poisoning, malware &amp; insecure code.</p><a class="more" href="docs.html#17-red-team">17-red-team →</a></div>


### PR DESCRIPTION
Everything shipped since v1.0.0, reflected in the public surfaces:

- **New `assets/shepherd-loop.svg`** — the pr-shepherd cycle (diagnose-from-logs → classify → fix+test → server-side-enforced merge gate → human inbox), twice-daily cadence chip, house diagram language, full alt text.
- **`assets/hardening-frontier.svg` updated** — 147-case bypass corpus (was 61), three cross-model gates chip (Claude · Codex · Gemini), hard budget ceiling chip; +84px band shift, everything else byte-stable.
- **README** — three-cross-model-gates wording in the loop claim, pr-shepherd + `compass schedule add pr-shepherd --twice-daily` in the loop-engineering row and Loops section (new SVG embedded), five loop scales.
- **Site** (content.js + index.html) — Gemini auditor, budget ceiling, inter-step quarantine, pr-shepherd rows in the existing entry formats.
- docs/16 alt text matches the updated SVG. No competitor names anywhere. Honest split kept: 61-case bench corpus vs 147-case bypass corpus.

## Verification (re-run by the driver after rebase onto #83)
xmllint both SVGs clean · `node --check content.js` OK · doctor **143 ok/0**