### PR TITLE
release: v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-07-26
+
 ### Added
 
 - **`pr-shepherd` scheduled routine** — `compass schedule add pr-shepherd --twice-daily`

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,20 +1,31 @@
 {
   "name": "compass",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "compass — one operating manual + eval-gated guardrails, red-team hardening, a cost-tier router and signed config for your coding agent. Loads the manual as GEMINI.md and wires the same version-pinned MCP servers (context7 · fetch · git) compass uses for Claude Code and Codex.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "context7": {
       "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp@3.1.0"]
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@3.1.0"
+      ]
     },
     "fetch": {
       "command": "uvx",
-      "args": ["--from", "mcp-server-fetch==2025.4.7", "mcp-server-fetch"]
+      "args": [
+        "--from",
+        "mcp-server-fetch==2025.4.7",
+        "mcp-server-fetch"
+      ]
     },
     "git": {
       "command": "uvx",
-      "args": ["--from", "mcp-server-git==2026.1.14", "mcp-server-git"]
+      "args": [
+        "--from",
+        "mcp-server-git==2026.1.14",
+        "mcp-server-git"
+      ]
     }
   }
 }

--- a/plugins/core-lsp/.claude-plugin/plugin.json
+++ b/plugins/core-lsp/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "core-lsp",
   "displayName": "compass — LSP",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Language-server intelligence (diagnostics, navigation) for Go, Rust, TypeScript, and Python. Opt-in companion to core — requires the language servers installed on PATH.",
   "author": {
     "name": "Shekhar Mudarapu",
@@ -11,5 +11,12 @@
   "homepage": "https://github.com/dshakes/compass/tree/main/plugins/core-lsp",
   "repository": "https://github.com/dshakes/compass",
   "license": "MIT",
-  "keywords": ["lsp", "gopls", "rust-analyzer", "typescript", "pyright", "diagnostics"]
+  "keywords": [
+    "lsp",
+    "gopls",
+    "rust-analyzer",
+    "typescript",
+    "pyright",
+    "diagnostics"
+  ]
 }

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "compass",
   "displayName": "compass",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Cost-tiered specialist subagents, workflow commands, guardrail + live-budget-ceiling + auto-quality hooks, a repo-bootstrap skill, a terse output style, and parity MCP servers — for serious polyglot software work.",
   "author": {
     "name": "Shekhar Mudarapu",
@@ -11,5 +11,17 @@
   "homepage": "https://github.com/dshakes/compass#readme",
   "repository": "https://github.com/dshakes/compass",
   "license": "MIT",
-  "keywords": ["subagents", "hooks", "code-review", "security-review", "cost-optimization", "budget-control", "mcp", "go", "rust", "typescript", "kubernetes"]
+  "keywords": [
+    "subagents",
+    "hooks",
+    "code-review",
+    "security-review",
+    "cost-optimization",
+    "budget-control",
+    "mcp",
+    "go",
+    "rust",
+    "typescript",
+    "kubernetes"
+  ]
 }

--- a/plugins/core/.codex-plugin/plugin.json
+++ b/plugins/core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Cost-tiered specialist subagents, workflow commands, guardrail + red-team + auto-quality hooks, repo-bootstrap and using-compass skills, and parity MCP servers — for serious polyglot software work.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
@@ -12,7 +12,15 @@
   "homepage": "https://github.com/dshakes/compass#readme",
   "repository": "https://github.com/dshakes/compass",
   "license": "MIT",
-  "keywords": ["subagents", "hooks", "code-review", "security-review", "red-team", "cost-optimization", "mcp"],
+  "keywords": [
+    "subagents",
+    "hooks",
+    "code-review",
+    "security-review",
+    "red-team",
+    "cost-optimization",
+    "mcp"
+  ],
   "interface": {
     "displayName": "Core",
     "category": "Developer Tools"


### PR DESCRIPTION
Version bump for the v2.0.0 cut: all four vendor manifests → 2.0.0 (check-vendor enforces lockstep), CHANGELOG `[2.0.0] - 2026-07-26` heading.

**Major** per SemVer: plugin id `core` → `compass` breaks existing plugin installs (migration documented). Everything else additive: pr-shepherd (skill + command + twice-daily routine), Gemini third cross-model gate, SDLC_BUDGET hard ceiling, inter-step injection quarantine, routing feedback, merge-queue-ready workflows + required-checks ruleset, 147-case corpus, hook corpus, ADR-0007, name-scrubbed docs, brand refresh.

After merge: dispatch `release.yml` (tags v2.0.0, publishes with CHANGELOG notes, opens formula-bump PR), release-sign adds SLSA on the tag, formula PR merged, `compass verify v2.0.0`.

## Verification
check-vendor lockstep green · doctor **143 ok/0** · plugin+marketplace `claude plugin validate` pass · sync in sync