### PR TITLE
fix(release): set git identity before creating the annotated tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
           if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
             echo "tag $VERSION already on origin — skipping"
           else
+            # Runners have no git identity; annotated tags need one (empty-ident fatal).
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git tag -a "$VERSION" -m "compass $VERSION"
             git push origin "refs/tags/$VERSION"
           fi

--- a/sdlc/workflows/release.yml
+++ b/sdlc/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
           if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
             echo "tag $VERSION already on origin — skipping"
           else
+            # Runners have no git identity; annotated tags need one (empty-ident fatal).
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git tag -a "$VERSION" -m "compass $VERSION"
             git push origin "refs/tags/$VERSION"
           fi


### PR DESCRIPTION
v2.0.0 dispatch failed at 'Create and push the tag': runners have no git identity and `git tag -a` requires one (`fatal: empty ident name`). This dispatch path was never exercised before — v1.0.0 was tagged locally via scripts/release.sh. Fix: configure the actions-bot identity in the step.

Verification: actions audit **17/0** (mirror in sync) · actionlint clean at CI severity.