### PR TITLE
chore(release): pin v2.0.0 + tarball sha in the Homebrew formula

### DIFF
--- a/Formula/compass.rb
+++ b/Formula/compass.rb
@@ -8,8 +8,8 @@
 class Compass < Formula
   desc "Measured guardrails, a budget cap, and a self-fixing loop for AI coding agents"
   homepage "https://github.com/dshakes/compass"
-  url "https://github.com/dshakes/compass/archive/refs/tags/v1.0.0.tar.gz"
-  sha256 "10a16ed3f9e5aeefcb94b50cfeaa53d0ec95891442d5e061a7beab8c59d150ff"
+  url "https://github.com/dshakes/compass/archive/refs/tags/v2.0.0.tar.gz"
+  sha256 "834f04e96c098084077543d5d774946fdcb94c130923921ab22d26e6177c009b"
   license "MIT"
   head "https://github.com/dshakes/compass.git", branch: "main"
 


### PR DESCRIPTION
Formula bump for v2.0.0 (branch pushed by release.yml; PR opened manually — Actions lacked PR-creation permission at run time, now enabled). ci's formula-freshness gate on main requires this to merge.