### PR TITLE
feat(sdlc): fix-loop hardening — update-branch-first + verdict fallback

### DIFF
--- a/.github/workflows/sdlc-fix.yml
+++ b/.github/workflows/sdlc-fix.yml
@@ -57,6 +57,18 @@ jobs:
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # Cheapest fix first: a PR behind its base can carry FALSE reds (stale-base
+          # reviews/audits — seen live on #81). Update the branch and let checks re-run
+          # before spending model tokens; this round is free (no round label consumed).
+          behind="$(gh pr view "$PR" --json mergeStateStatus --jq .mergeStateStatus 2>/dev/null || echo '')"
+          if [ "$behind" = "BEHIND" ]; then
+            if gh pr update-branch "$PR" >/dev/null 2>&1; then
+              gh pr comment "$PR" --body "🔄 Branch was behind base — updated it first; checks re-run before any model fix (stale-base reds are often false)." >/dev/null 2>&1 || true
+              echo "PR behind base — updated branch, deferring model fix to the re-run."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
           round=0
           for n in $(seq 1 50); do
             printf '%s\n' "$labels" | grep -qx "sdlc:round-$n" && round=$n

--- a/.github/workflows/sdlc-review.yml
+++ b/.github/workflows/sdlc-review.yml
@@ -134,6 +134,10 @@ jobs:
             gh pr edit "$PR" --remove-label "agent:reviewed-clean" >/dev/null 2>&1 || true
             gh pr edit "$PR" --remove-label "agent:needs-fix"      >/dev/null 2>&1 || true
             gh pr edit "$PR" --add-label    "agent:needs-fix"
+            # Fail-safe: the model's own findings comment can fail to post (seen on #83 —
+            # BLOCKING verdict, no comment, blind fixer). Always land at least the summary.
+            summary="$(printf '%s' "$OUT" | jq -r '.summary // ""' 2>/dev/null || true)"
+            [ -n "$summary" ] && gh pr comment "$PR" --body "🔒 **Reviewer verdict: BLOCKING** — $summary" >/dev/null 2>&1 || true
             echo "::error::Reviewer found Blocking issues — see the PR comments. Auto-fix loop engaged."
             exit 1
           fi

--- a/sdlc/workflows/sdlc-fix.yml
+++ b/sdlc/workflows/sdlc-fix.yml
@@ -57,6 +57,18 @@ jobs:
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # Cheapest fix first: a PR behind its base can carry FALSE reds (stale-base
+          # reviews/audits — seen live on #81). Update the branch and let checks re-run
+          # before spending model tokens; this round is free (no round label consumed).
+          behind="$(gh pr view "$PR" --json mergeStateStatus --jq .mergeStateStatus 2>/dev/null || echo '')"
+          if [ "$behind" = "BEHIND" ]; then
+            if gh pr update-branch "$PR" >/dev/null 2>&1; then
+              gh pr comment "$PR" --body "🔄 Branch was behind base — updated it first; checks re-run before any model fix (stale-base reds are often false)." >/dev/null 2>&1 || true
+              echo "PR behind base — updated branch, deferring model fix to the re-run."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
           round=0
           for n in $(seq 1 50); do
             printf '%s\n' "$labels" | grep -qx "sdlc:round-$n" && round=$n

--- a/sdlc/workflows/sdlc-review.yml
+++ b/sdlc/workflows/sdlc-review.yml
@@ -134,6 +134,10 @@ jobs:
             gh pr edit "$PR" --remove-label "agent:reviewed-clean" >/dev/null 2>&1 || true
             gh pr edit "$PR" --remove-label "agent:needs-fix"      >/dev/null 2>&1 || true
             gh pr edit "$PR" --add-label    "agent:needs-fix"
+            # Fail-safe: the model's own findings comment can fail to post (seen on #83 —
+            # BLOCKING verdict, no comment, blind fixer). Always land at least the summary.
+            summary="$(printf '%s' "$OUT" | jq -r '.summary // ""' 2>/dev/null || true)"
+            [ -n "$summary" ] && gh pr comment "$PR" --body "🔒 **Reviewer verdict: BLOCKING** — $summary" >/dev/null 2>&1 || true
             echo "::error::Reviewer found Blocking issues — see the PR comments. Auto-fix loop engaged."
             exit 1
           fi


### PR DESCRIPTION
Two agentic-CI-fix upgrades, each from a failure observed live this week:

1. **update-branch-first** (#81): stale-base reviews produce false reds; the fixer then 'fixes' true claims. Now: `mergeStateStatus == BEHIND` → `gh pr update-branch`, defer to the re-run, consume no fix round.
2. **Verdict comment fallback** (#83): reviewer returned BLOCKING but its findings comment never posted — the fix agent had nothing to work from. The deterministic label step now always posts at least the structured summary.

Verification: actions audit **17/0** (mirrors in lockstep) · actionlint clean at CI severity.