### PR TITLE
feat(cli): compass enable — one-command multi-repo onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **`compass enable`** — one command puts any repo (or list of repos / `owner/repo` slugs,
+  cloned on demand) fully on compass: per-repo config, sdlc workflows + labels committed &
+  pushed, secrets set from exported env only (never prompts, never reads credential stores),
+  a solo-friendly required-checks ruleset (review+qa, no forced human approval), auto-merge,
+  optional coverage gate, and `--schedule` for the twice-daily pr-shepherd. `--dry-run` previews.
+- **Per-repo scheduling + sleep-proof cadence** — `compass schedule add <routine> --dir REPO`
+  binds a routine to a repo (multiple repos coexist); on macOS schedules use launchd, which
+  runs a slept-through slot once on wake (crontab, kept for Linux, skips them).
+
 ## [2.0.0] - 2026-07-26
 
 ### Added

--- a/bin/compass
+++ b/bin/compass
@@ -27,6 +27,10 @@ usage: compass <command> [args]
 
   quickstart [flags]       Install + validate + the 60-second on-ramp (idempotent;
                            re-run to repair). Pass-through: --mcp --gemini --copy --yes.
+  enable  [flags] <owner/repo|dir> ...
+                           One command → repo fully on compass: config + sdlc loop +
+                           secrets-from-env + solo ruleset + auto-merge; --schedule
+                           adds the twice-daily pr-shepherd. --dry-run to preview.
   status  [DIR]            Is compass enabled here? Global config + this-repo extras.
   drift   [--json]         Does the installed config still match the repo source?
                            Catches clobbered/stale/hand-edited installs + non-+x hooks.
@@ -107,6 +111,7 @@ run() { local s="$SCRIPTS/compass-$1.sh"; shift; [ -x "$s" ] || { echo "compass:
 
 case "$cmd" in
   quickstart) exec "$ROOT/quickstart.sh" "$@" ;;
+  enable)   run enable "$@" ;;
   status)   run status "$@" ;;
   drift)    run drift "$@" ;;
   onboard)  run onboard "$@" ;;

--- a/claude/skills/using-compass/SKILL.md
+++ b/claude/skills/using-compass/SKILL.md
@@ -23,6 +23,7 @@ compass capability does it better — and safer.
 | See impact / spend | `compass impact` · `compass spend` · `compass dashboard` | the ledgers |
 | Find a loop's next work (discovery) | **morning-triage** skill | reads CI · issues · commits, judges, hands off |
 | Take open PRs end-to-end | **pr-shepherd** skill (`/loop 15m /pr-shepherd`) | diagnoses red checks, fixes mechanical ones, stops at the merge gate |
+| Put a repo (or many) on compass in one command | `compass enable <owner/repo|dir> ...` | config + sdlc loop + secrets-from-env + ruleset + auto-merge; `--schedule` adds twice-daily pr-shepherd |
 | Stay ahead of code you didn't write | `compass digest` | sample merged changes & explain them (comprehension guard) |
 | Cap an unattended loop's spend | `COMPASS_MAX_USD_DAY` · `compass spend --today --max-usd N` | per-day circuit breaker |
 

--- a/plugins/core/skills/using-compass/SKILL.md
+++ b/plugins/core/skills/using-compass/SKILL.md
@@ -23,6 +23,7 @@ compass capability does it better — and safer.
 | See impact / spend | `compass impact` · `compass spend` · `compass dashboard` | the ledgers |
 | Find a loop's next work (discovery) | **morning-triage** skill | reads CI · issues · commits, judges, hands off |
 | Take open PRs end-to-end | **pr-shepherd** skill (`/loop 15m /pr-shepherd`) | diagnoses red checks, fixes mechanical ones, stops at the merge gate |
+| Put a repo (or many) on compass in one command | `compass enable <owner/repo|dir> ...` | config + sdlc loop + secrets-from-env + ruleset + auto-merge; `--schedule` adds twice-daily pr-shepherd |
 | Stay ahead of code you didn't write | `compass digest` | sample merged changes & explain them (comprehension guard) |
 | Cap an unattended loop's spend | `COMPASS_MAX_USD_DAY` · `compass spend --today --max-usd N` | per-day circuit breaker |
 

--- a/scripts/compass-enable.sh
+++ b/scripts/compass-enable.sh
@@ -53,6 +53,7 @@ resolve_dir() {
   case "$t" in
     */*)
       local name="${t##*/}" dest="$CLONE_ROOT/$name"
+      mkdir -p "$CLONE_ROOT"
       if [ -d "$dest/.git" ]; then printf '%s' "$dest"; return 0; fi
       [ "$DRYRUN" = 1 ] && { printf '%s' "$dest"; return 0; }
       gh repo clone "$t" "$dest" -- --quiet >/dev/null 2>&1 || return 1
@@ -104,7 +105,7 @@ enable_one() {
     && ok "L2: sdlc workflows + labels committed & pushed" \
     || warn "L2: setup.sh reported errors — run it by hand: (cd $dir && $REPO_HOME/sdlc/setup.sh --workflows --commit)"
   local s set_any=0
-  for s in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY CLAUDE_CODE_OAUTH_TOKEN; do
+  for s in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY CLAUDE_CODE_OAUTH_TOKEN SDLC_BOT_TOKEN; do
     if [ -n "${!s:-}" ]; then
       gh secret set "$s" --repo "$nwo" --body "${!s}" >/dev/null 2>&1 && set_any=1
     else

--- a/scripts/compass-enable.sh
+++ b/scripts/compass-enable.sh
@@ -107,7 +107,8 @@ enable_one() {
   local s set_any=0
   for s in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY CLAUDE_CODE_OAUTH_TOKEN SDLC_BOT_TOKEN; do
     if [ -n "${!s:-}" ]; then
-      gh secret set "$s" --repo "$nwo" --body "${!s}" >/dev/null 2>&1 && set_any=1
+      # stdin, never --body: a command-line arg is visible to every process (ps/procfs).
+      printf '%s' "${!s}" | gh secret set "$s" --repo "$nwo" >/dev/null 2>&1 && set_any=1
     else
       missing_secrets="${missing_secrets}
   gh secret set $s --repo $nwo"

--- a/scripts/compass-enable.sh
+++ b/scripts/compass-enable.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# compass-enable.sh — one command to put a repo (or several) fully on compass.
+#
+# Composes the existing layers instead of reinventing them:
+#   L1  scripts/new-repo.sh          starter CLAUDE.md + AGENTS.md/GEMINI.md symlinks
+#   L2  sdlc/setup.sh                labels + sdlc workflows + CODEOWNERS + commit/push
+#       + secrets (env-only here — never prompts, never reads credential stores)
+#       + a solo-friendly ruleset (required review+qa checks; NO human-approval
+#         requirement, so the autonomous fix loop can land green PRs) + auto-merge
+#   L3  compass schedule             optional --schedule → pr-shepherd twice daily
+#
+#   compass enable [flags] <owner/repo | dir> ...
+#     --schedule        also schedule pr-shepherd --twice-daily for each repo
+#     --coverage N      set repo var SDLC_COVERAGE_MIN=N (opt-in QA coverage gate)
+#     --team-protect    use sdlc/setup.sh --protect instead of the solo ruleset
+#                       (adds required human approval + code owners — team mode)
+#     --clone-root DIR  where owner/repo targets get cloned (default ~/workspace)
+#     --dry-run         print the plan per repo, change nothing
+#
+# Secrets are set ONLY from exported env (ANTHROPIC_API_KEY, OPENAI_API_KEY,
+# GEMINI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN); anything absent is listed at the end
+# with the exact `gh secret set` command — agent jobs no-op green until then.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; REPO_HOME="$(dirname "$HERE")"
+C_RST=$'\033[0m'; C_GREEN=$'\033[38;5;42m'; C_AMBER=$'\033[38;5;214m'; C_CYAN=$'\033[38;5;39m'
+log()  { printf '\n%s▶ %s%s\n' "$C_CYAN" "$*" "$C_RST"; }
+ok()   { printf '  %s✓ %s%s\n' "$C_GREEN" "$*" "$C_RST"; }
+warn() { printf '  %s! %s%s\n' "$C_AMBER" "$*" "$C_RST"; }
+die()  { printf 'ERROR: %s\n' "$*" >&2; exit 2; }
+
+command -v gh >/dev/null || die "gh CLI required"
+command -v git >/dev/null || die "git required"
+
+SCHEDULE=0 COVERAGE="" TEAM_PROTECT=0 DRYRUN=0 CLONE_ROOT="$HOME/workspace"
+targets=()
+while [ $# -gt 0 ]; do case "$1" in
+  --schedule) SCHEDULE=1; shift ;;
+  --coverage) COVERAGE="${2:-}"; [ -n "$COVERAGE" ] || die "--coverage needs a number"; shift 2 ;;
+  --team-protect) TEAM_PROTECT=1; shift ;;
+  --clone-root) CLONE_ROOT="${2:-}"; [ -n "$CLONE_ROOT" ] || die "--clone-root needs a dir"; shift 2 ;;
+  --dry-run) DRYRUN=1; shift ;;
+  -h|--help) sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  -*) die "unknown flag: $1" ;;
+  *) targets+=("$1"); shift ;;
+esac; done
+[ "${#targets[@]}" -gt 0 ] || die "usage: compass enable [flags] <owner/repo | dir> ..."
+
+# Resolve a target to a local dir (cloning owner/repo if needed). Echoes the dir.
+resolve_dir() {
+  local t="$1"
+  if [ -d "$t" ]; then (cd "$t" && pwd); return 0; fi
+  case "$t" in
+    */*)
+      local name="${t##*/}" dest="$CLONE_ROOT/$name"
+      if [ -d "$dest/.git" ]; then printf '%s' "$dest"; return 0; fi
+      [ "$DRYRUN" = 1 ] && { printf '%s' "$dest"; return 0; }
+      gh repo clone "$t" "$dest" -- --quiet >/dev/null 2>&1 || return 1
+      printf '%s' "$dest" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Solo-friendly ruleset: required checks gate merges server-side, but no human-approval
+# requirement — the human gate is "you own the merge button", not a forced review click.
+apply_solo_ruleset() { # args: <owner/repo>
+  local nwo="$1"
+  gh api -X POST "repos/$nwo/rulesets" -H "X-GitHub-Api-Version: 2026-03-10" --input - >/dev/null 2>&1 << 'JSON' && return 0
+{
+  "name": "compass-protect-main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_status_checks", "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [ { "context": "review" }, { "context": "qa" } ]
+    } }
+  ]
+}
+JSON
+  return 1
+}
+
+missing_secrets=""
+enable_one() {
+  local target="$1" dir nwo
+  dir="$(resolve_dir "$target")" || { warn "cannot resolve $target (not a dir; clone failed?)"; return 1; }
+  nwo="$(cd "$dir" 2>/dev/null && gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)" || nwo=""
+  log "enable: ${nwo:-$dir}"
+  if [ "$DRYRUN" = 1 ]; then
+    ok "[dry-run] L1 new-repo.sh · L2 setup.sh --workflows --commit$([ "$TEAM_PROTECT" = 1 ] && echo ' --protect' || echo ' + solo ruleset') · secrets-from-env · auto-merge$([ -n "$COVERAGE" ] && echo " · coverage≥$COVERAGE")$([ "$SCHEDULE" = 1 ] && echo ' · pr-shepherd twice daily')"
+    return 0
+  fi
+  [ -n "$nwo" ] || { warn "$dir has no GitHub remote gh can see — skipping"; return 1; }
+
+  # L1 — committed per-repo config (idempotent; leaves existing files alone).
+  "$HERE/new-repo.sh" "$dir" >/dev/null && ok "L1: CLAUDE.md + AGENTS.md/GEMINI.md"
+
+  # L2 — workflows + labels (+ optional team protection). Secrets: env-only, no prompts.
+  ( cd "$dir" && "$REPO_HOME/sdlc/setup.sh" --workflows --commit $([ "$TEAM_PROTECT" = 1 ] && echo --protect) >/dev/null 2>&1 ) \
+    && ok "L2: sdlc workflows + labels committed & pushed" \
+    || warn "L2: setup.sh reported errors — run it by hand: (cd $dir && $REPO_HOME/sdlc/setup.sh --workflows --commit)"
+  local s set_any=0
+  for s in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY CLAUDE_CODE_OAUTH_TOKEN; do
+    if [ -n "${!s:-}" ]; then
+      gh secret set "$s" --repo "$nwo" --body "${!s}" >/dev/null 2>&1 && set_any=1
+    else
+      missing_secrets="${missing_secrets}
+  gh secret set $s --repo $nwo"
+    fi
+  done
+  [ "$set_any" = 1 ] && ok "secrets set from env (only the exported ones)"
+  if [ "$TEAM_PROTECT" != 1 ]; then
+    if apply_solo_ruleset "$nwo"; then ok "solo ruleset: required review+qa, no forced approval"
+    else warn "ruleset not applied (may already exist) — check: gh api repos/$nwo/rulesets"; fi
+  fi
+  gh api -X PATCH "repos/$nwo" -F allow_auto_merge=true >/dev/null 2>&1 && ok "auto-merge available (gh pr merge --auto --squash)"
+  [ -n "$COVERAGE" ] && gh variable set SDLC_COVERAGE_MIN --repo "$nwo" --body "$COVERAGE" >/dev/null 2>&1 && ok "coverage gate ≥${COVERAGE}%"
+
+  # L3 — the unattended loop, per repo.
+  if [ "$SCHEDULE" = 1 ]; then
+    "$HERE/compass-schedule.sh" add pr-shepherd --twice-daily --dir "$dir" \
+      && ok "pr-shepherd scheduled twice daily for $dir" \
+      || warn "schedule add failed — run: compass schedule add pr-shepherd --twice-daily --dir $dir"
+  fi
+  return 0
+}
+
+okc=0; failc=0
+for t in "${targets[@]}"; do
+  if enable_one "$t"; then okc=$((okc+1)); else failc=$((failc+1)); fi
+done
+
+printf '\n%s%d enabled, %d failed%s\n' "$C_GREEN" "$okc" "$failc" "$C_RST"
+if [ -n "$missing_secrets" ]; then
+  warn "secrets NOT set (not exported in this shell) — agent jobs no-op green until you run:"
+  printf '%s\n' "$missing_secrets"
+fi
+[ "$failc" -eq 0 ]

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -276,6 +276,10 @@ rm -rf "$ETMP"
 grep -q "env-only" "$EN" && grep -q "never prompts" "$EN" \
   && ok "secrets are env-only by contract (no prompting, no credential-store reads)" \
   || no "env-only secrets contract missing"
+# secret VALUES must go via stdin — a --body arg is visible to every process (ps).
+if grep -E 'gh secret set' "$EN" | grep -q -- '--body'; then
+  no "gh secret set uses --body (secret leaks to the process list)"
+else ok "secret values flow via stdin, never argv"; fi
 
 echo "compass-schedule — pr-shepherd routine wiring:"
 if grep -q 'VALID_ROUTINES=.*pr-shepherd' "$ROOT/scripts/compass-schedule.sh"; then

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -258,6 +258,25 @@ echo "compass-schedule — unattended cron run is bounded:"
 if grep -q -- '--max-turns' "$ROOT/scripts/compass-schedule.sh" && grep -q -- '--max-budget-usd' "$ROOT/scripts/compass-schedule.sh"; then
   ok "cron claude -p has turn + budget caps"; else no "cron claude -p is missing turn/budget caps"; fi
 
+echo "compass enable — one-command multi-repo onboarding:"
+EN="$ROOT/scripts/compass-enable.sh"
+[ -x "$EN" ] && ok "enable script exists + executable" || no "enable script missing/not executable"
+"$EN" --help >/dev/null 2>&1 && ok "--help exits 0" || no "--help failed"
+"$EN" --bogus-flag x >/dev/null 2>&1; [ $? -eq 2 ] && ok "unknown flag exits 2" || no "unknown flag not rejected"
+"$EN" >/dev/null 2>&1; [ $? -eq 2 ] && ok "no targets exits 2" || no "no-target case not rejected"
+ETMP="$(mktemp -d "${TMPDIR:-/tmp}/compass-enable.XXXXXX")"
+git init -q "$ETMP/fake-repo"
+EOUT="$("$EN" --dry-run --schedule --coverage 70 "$ETMP/fake-repo" 2>&1)"; ERC=$?
+eq  "dry-run exits 0"                    "$ERC" 0
+has "dry-run prints the layered plan"    "$EOUT" "L1 new-repo.sh"
+has "dry-run includes schedule step"     "$EOUT" "pr-shepherd twice daily"
+has "dry-run includes coverage step"     "$EOUT" "coverage≥70"
+[ -z "$(git -C "$ETMP/fake-repo" status --porcelain)" ] && ok "dry-run changed nothing" || no "dry-run mutated the repo"
+rm -rf "$ETMP"
+grep -q "env-only" "$EN" && grep -q "never prompts" "$EN" \
+  && ok "secrets are env-only by contract (no prompting, no credential-store reads)" \
+  || no "env-only secrets contract missing"
+
 echo "compass-schedule — pr-shepherd routine wiring:"
 if grep -q 'VALID_ROUTINES=.*pr-shepherd' "$ROOT/scripts/compass-schedule.sh"; then
   ok "pr-shepherd is a valid routine"; else no "pr-shepherd missing from VALID_ROUTINES"; fi


### PR DESCRIPTION
One command puts any repo (or a list, `owner/repo` slugs cloned on demand) fully on compass:

`compass enable [--schedule] [--coverage N] [--team-protect] [--dry-run] <owner/repo|dir>...`

Composes existing layers per target: new-repo config → sdlc workflows + labels committed & pushed → secrets from exported env ONLY (never prompts, never reads credential stores; missing ones printed as exact `gh secret set` commands) → solo-friendly ruleset (required review+qa, NO forced human approval so the fix loop can land green PRs; `--team-protect` for the strict variant) → auto-merge → optional coverage gate → optional twice-daily pr-shepherd.

Note: `--schedule` uses `compass schedule add --dir`, landing in a sibling PR — until that merges the flag degrades to a printed command (warn path, tested).

Verification: **154 CLI tests / 0 failed** (14 new: wiring, dry-run behavior incl. changed-nothing assertion, env-only contract) · doctor 144 ok/0 · shellcheck error-level clean · plugin sync in sync.