### PR TITLE
feat(schedule): per-repo routines + sleep-proof launchd cadence on macOS

### DIFF
--- a/scripts/compass-schedule.sh
+++ b/scripts/compass-schedule.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
-# compass-schedule.sh — manage local scheduled compass routines via crontab.
+# compass-schedule.sh — manage local scheduled compass routines.
 #
 # Subcommands:
-#   add <routine> [--daily|--weekly|--cron "<expr>"]
+#   add <routine> [--daily|--twice-daily|--weekly|--cron "<expr>"] [--dir DIR]
 #   list
-#   remove <routine>
+#   remove <routine> [--dir DIR]
 #   run <routine> [DIR]
 #
 # Routines: dep-refresh  flaky-triage  doc-freshness  pr-babysit  ci-watch  pr-shepherd
+#
+# Backend: launchd user agents on macOS (sleep-missed runs fire once on wake);
+# crontab on Linux and for --cron expressions (cron skips sleep-missed slots).
 #
 # Crontab block is delimited by:
 #   # >>> compass schedule >>>
@@ -26,6 +29,18 @@ SPEND_LEDGER="$COMPASS_HOME/spend.tsv"
 
 BLOCK_OPEN="# >>> compass schedule >>>"
 BLOCK_CLOSE="# <<< compass schedule <<<"
+
+OS="$(uname)"
+DRYRUN="${COMPASS_SCHEDULE_DRYRUN:-0}"
+
+# launchd user-agent plists live here (dry-run redirects under $COMPASS_HOME so
+# tests never install real agents).
+if [ "$DRYRUN" = "1" ]; then
+  LAUNCH_DIR="$COMPASS_HOME/dryrun-launchagents"
+  DRYRUN_CRONTAB="$COMPASS_HOME/dryrun-crontab"
+else
+  LAUNCH_DIR="$HOME/Library/LaunchAgents"
+fi
 
 # ---------------------------------------------------------------------------
 # Valid routines (space-separated; validated by validate_routine)
@@ -51,25 +66,37 @@ PR_SHEPHERD_EXTRA_TOOLS="${CI_WATCH_EXTRA_TOOLS},Bash(git worktree:*),Bash(gh pr
 # ---------------------------------------------------------------------------
 usage() {
   cat <<'EOF'
-compass schedule — manage local scheduled routines via crontab
+compass schedule — manage local scheduled routines (launchd on macOS, crontab on Linux)
 
 Usage:
-  compass schedule add <routine> [--daily|--weekly|--cron "<expr>"]
+  compass schedule add <routine> [--daily|--twice-daily|--weekly|--cron "<expr>"] [--dir DIR]
   compass schedule list
-  compass schedule remove <routine>
+  compass schedule remove <routine> [--dir DIR]
   compass schedule run <routine> [DIR]
   compass schedule -h|--help
 
 Routines: dep-refresh  flaky-triage  doc-freshness  pr-babysit  ci-watch  pr-shepherd
 
 Schedule flags:
-  --daily             0 6 * * *   (daily at 06:00)
-  --twice-daily       7 9,17 * * *  (09:07 + 17:07 — crontab only fires while the laptop is awake; missed slots are skipped, not caught up)
-  --weekly            0 6 * * 1   (Mondays at 06:00)  [default]
-  --cron "<expr>"     custom 5-field cron expression
+  --daily             daily at 06:00
+  --twice-daily       09:07 + 17:07 (off-minute on purpose)
+  --weekly            Mondays at 06:00  [default]
+  --cron "<expr>"     custom 5-field cron expression (always crontab — cron only
+                      fires while the machine is awake; missed slots are skipped)
+  --dir DIR           repo the routine runs in (default: current directory).
+                      The same routine can be scheduled for several repos; each
+                      gets its own entry. `remove <routine> --dir DIR` removes
+                      only that repo's entry; without --dir, all of them.
 
-The cron job invokes:
-  ~/compass/bin/compass schedule run <routine>
+Backends:
+  macOS   add writes a launchd user agent
+          (~/Library/LaunchAgents/com.compass.schedule.<routine>.<dir-slug>.plist).
+          launchd runs a missed StartCalendarInterval job once on wake, so
+          sleep-missed slots are caught up. --cron falls back to crontab.
+  Linux   crontab, managed inside the compass block markers.
+
+The job invokes:
+  cd DIR && <repo>/bin/compass schedule run <routine> DIR
 and appends output to ~/.compass/schedule.log.
 
 Spend is appended to ${COMPASS_HOME:-~/.compass}/spend.tsv.
@@ -92,13 +119,26 @@ prompt_file() {
   printf '%s/%s.md' "$PROMPTS_DIR" "$name"
 }
 
+# Filesystem-safe slug of a directory path (for launchd labels/filenames).
+dir_slug() {
+  printf '%s' "$1" | tr -cs 'a-zA-Z0-9' '-'
+}
+
+xml_escape() {
+  printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
+
 # ---------------------------------------------------------------------------
 # Crontab block management
 # ---------------------------------------------------------------------------
 
-# Read the current crontab (tolerate missing/empty).
+# Read the current crontab (tolerate missing/empty). Dry-run reads a file.
 read_crontab() {
-  crontab -l 2>/dev/null || true
+  if [ "$DRYRUN" = "1" ]; then
+    cat "$DRYRUN_CRONTAB" 2>/dev/null || true
+  else
+    crontab -l 2>/dev/null || true
+  fi
 }
 
 # Extract lines OUTSIDE the managed block.
@@ -121,7 +161,26 @@ inside_block() {
   '
 }
 
-# Rebuild and install the crontab.
+# Filter OUT managed entries for a routine. $2 empty = every entry for the
+# routine (dir-scoped and legacy dir-less); $2 set = only that exact dir.
+# Exact fixed-string suffix match — no regex, so paths can't over-match.
+strip_entries() {
+  local routine="$1" dir="${2:-}"
+  awk -v r="$routine" -v d="$dir" '
+    {
+      if (d == "") {
+        if (index($0, "# compass:" r ":") > 0) next
+        legacy = "# compass:" r
+        if (length($0) >= length(legacy) && substr($0, length($0)-length(legacy)+1) == legacy) next
+      } else {
+        key = "# compass:" r ":" d
+        if (length($0) >= length(key) && substr($0, length($0)-length(key)+1) == key) next
+      }
+      print
+    }'
+}
+
+# Rebuild and install the crontab. Dry-run writes a file instead.
 install_crontab() {
   local outside="$1"   # lines outside our block
   local entries="$2"   # lines inside our block (may be empty)
@@ -148,6 +207,16 @@ ${BLOCK_CLOSE}"
     new_tab="$outside"
   fi
 
+  if [ "$DRYRUN" = "1" ]; then
+    if [ -z "${new_tab//[[:space:]]/}" ]; then
+      rm -f "$DRYRUN_CRONTAB"
+    else
+      mkdir -p "$COMPASS_HOME"
+      printf '%s\n' "$new_tab" > "$DRYRUN_CRONTAB"
+    fi
+    return 0
+  fi
+
   if [ -z "${new_tab//[[:space:]]/}" ]; then
     crontab -r 2>/dev/null || true   # nothing left to schedule — leave no stray crontab
   else
@@ -155,30 +224,94 @@ ${BLOCK_CLOSE}"
   fi
 }
 
-# Build a cron entry line for a given routine and cron expression.
-# NOTE: $REPO_HOME and $DISPATCHER are expanded now (script author's paths).
+# --- pure generators (no side effects; tests call these directly) -----------
+
+# Build a cron entry line for a routine + cron expression + target dir.
+# NOTE: $DISPATCHER is expanded now (script author's path).
 # The cron log path uses a literal $HOME so cron expands it per-user at runtime.
 make_entry() {
-  local expr="$1" routine="$2"
+  local expr="$1" routine="$2" dir="$3"
   # shellcheck disable=SC2016  # $HOME intentionally not expanded here
-  printf '%s cd "%s" && "%s" schedule run "%s" >> "$HOME/.compass/schedule.log" 2>&1  # compass:%s' \
-    "$expr" "$REPO_HOME" "$DISPATCHER" "$routine" "$routine"
+  printf '%s cd "%s" && "%s" schedule run "%s" "%s" >> "$HOME/.compass/schedule.log" 2>&1  # compass:%s:%s' \
+    "$expr" "$dir" "$DISPATCHER" "$routine" "$dir" "$routine" "$dir"
+}
+
+plist_label() {
+  local routine="$1" dir="$2"
+  printf 'com.compass.schedule.%s.%s' "$routine" "$(dir_slug "$dir")"
+}
+
+# Emit the launchd user-agent plist XML for a routine + dir + cadence.
+make_plist() {
+  local routine="$1" dir="$2" cadence="$3"
+  local label intervals cmd
+  label="$(plist_label "$routine" "$dir")"
+  cmd="cd \"$dir\" && \"$DISPATCHER\" schedule run $routine \"$dir\" >> ~/.compass/schedule.log 2>&1"
+  case "$cadence" in
+    daily)       intervals='    <dict><key>Hour</key><integer>6</integer><key>Minute</key><integer>0</integer></dict>' ;;
+    twice-daily) intervals='    <dict><key>Hour</key><integer>9</integer><key>Minute</key><integer>7</integer></dict>
+    <dict><key>Hour</key><integer>17</integer><key>Minute</key><integer>7</integer></dict>' ;;
+    weekly)      intervals='    <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>6</integer><key>Minute</key><integer>0</integer></dict>' ;;
+    *) die "no launchd mapping for cadence '$cadence'" ;;
+  esac
+  cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${label}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>bash</string>
+    <string>-lc</string>
+    <string>$(xml_escape "$cmd")</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <array>
+${intervals}
+  </array>
+  <key>RunAtLoad</key>
+  <false/>
+</dict>
+</plist>
+EOF
+}
+
+# --- launchd install/remove (no-ops under dry-run) --------------------------
+
+launchd_bootstrap() {
+  [ "$DRYRUN" = "1" ] && return 0
+  launchctl bootout "gui/$(id -u)" "$1" >/dev/null 2>&1 || true
+  launchctl bootstrap "gui/$(id -u)" "$1" >/dev/null 2>&1 \
+    || launchctl load "$1" >/dev/null 2>&1 || true
+}
+
+launchd_remove() {
+  if [ "$DRYRUN" != "1" ]; then
+    launchctl bootout "gui/$(id -u)" "$1" >/dev/null 2>&1 || true
+  fi
+  rm -f "$1"
 }
 
 # ---------------------------------------------------------------------------
 # Subcommand: add
 # ---------------------------------------------------------------------------
 cmd_add() {
-  local routine="" cron_expr="0 6 * * 1"   # default: weekly Monday 06:00
+  local routine="" cadence="weekly" cron_expr="0 6 * * 1" dir=""
 
   while [ $# -gt 0 ]; do
     case "$1" in
-      --daily)  cron_expr="0 6 * * *";  shift ;;
-      --twice-daily) cron_expr="7 9,17 * * *"; shift ;;   # off-minute on purpose (thundering-herd kindness)
-      --weekly) cron_expr="0 6 * * 1";  shift ;;
+      --daily)  cadence="daily";  cron_expr="0 6 * * *";  shift ;;
+      --twice-daily) cadence="twice-daily"; cron_expr="7 9,17 * * *"; shift ;;   # off-minute on purpose (thundering-herd kindness)
+      --weekly) cadence="weekly"; cron_expr="0 6 * * 1";  shift ;;
       --cron)
         [ $# -ge 2 ] || die "--cron requires an expression argument"
-        cron_expr="$2"; shift 2
+        cadence="cron"; cron_expr="$2"; shift 2
+        ;;
+      --dir)
+        [ $# -ge 2 ] || die "--dir requires a directory argument"
+        dir="$2"; shift 2
         ;;
       -*)  die "unknown flag '$1'" ;;
       *)
@@ -194,13 +327,47 @@ cmd_add() {
   local pf; pf="$(prompt_file "$routine")"
   [ -f "$pf" ] || die "prompt file not found: $pf"
 
+  # Resolve target dir (default: where the user ran `add`), absolute.
+  [ -n "$dir" ] || dir="$PWD"
+  [ -d "$dir" ] || die "directory not found: $dir"
+  dir="$(cd "$dir" && pwd)"
+
+  if [ "$OS" = "Darwin" ] && [ "$cadence" != "cron" ]; then
+    # launchd user agent — unlike cron, launchd runs a missed
+    # StartCalendarInterval job once on wake, so sleep doesn't drop runs.
+    mkdir -p "$LAUNCH_DIR"
+    local label plist
+    label="$(plist_label "$routine" "$dir")"
+    plist="$LAUNCH_DIR/$label.plist"
+    make_plist "$routine" "$dir" "$cadence" > "$plist"
+    launchd_bootstrap "$plist"
+    # Drop any crontab entry for the same routine+dir (e.g. from an earlier --cron add).
+    local tab outer inner
+    tab="$(read_crontab)"
+    outer="$(outside_block "$tab")"
+    inner="$(inside_block "$tab" | strip_entries "$routine" "$dir")"
+    install_crontab "$outer" "$inner"
+    printf 'scheduled (launchd): %s  [%s]  %s\n' "$routine" "$cadence" "$dir"
+    note "agent: $plist"
+    note "launchd runs a missed StartCalendarInterval job once on wake — sleep-missed slots are caught up."
+    return 0
+  fi
+
+  if [ "$OS" = "Darwin" ]; then
+    printf 'warning: --cron uses crontab — cron skips sleep-missed slots (they are not caught up on wake)\n' >&2
+    # Drop any launchd agent for the same routine+dir so the two backends don't double-fire.
+    local old_plist
+    old_plist="$LAUNCH_DIR/$(plist_label "$routine" "$dir").plist"
+    [ -f "$old_plist" ] && launchd_remove "$old_plist"
+  fi
+
   local tab; tab="$(read_crontab)"
   local outer; outer="$(outside_block "$tab")"
   local inner; inner="$(inside_block "$tab")"
 
-  # Remove any existing entry for this routine, then append the new one.
-  inner="$(printf '%s\n' "$inner" | grep -v "# compass:${routine}$" || true)"
-  local new_line; new_line="$(make_entry "$cron_expr" "$routine")"
+  # Remove any existing entry for this routine+dir, then append the new one.
+  inner="$(printf '%s\n' "$inner" | strip_entries "$routine" "$dir")"
+  local new_line; new_line="$(make_entry "$cron_expr" "$routine" "$dir")"
   if [ -n "$inner" ]; then
     inner="${inner}
 ${new_line}"
@@ -209,43 +376,100 @@ ${new_line}"
   fi
 
   install_crontab "$outer" "$inner"
-  printf 'scheduled: %s  [%s]\n' "$routine" "$cron_expr"
+  printf 'scheduled (cron): %s  [%s]  %s\n' "$routine" "$cron_expr" "$dir"
 }
 
 # ---------------------------------------------------------------------------
 # Subcommand: list
 # ---------------------------------------------------------------------------
 cmd_list() {
+  local found=0
   local tab; tab="$(read_crontab)"
   local inner; inner="$(inside_block "$tab")"
-  if [ -z "$inner" ]; then
-    printf 'no compass-managed schedule entries\n'
-  else
-    printf 'compass-managed schedule:\n'
+  if [ -n "$inner" ]; then
+    found=1
+    printf 'compass-managed schedule (crontab):\n'
     printf '%s\n' "$inner"
   fi
+
+  if [ "$OS" = "Darwin" ] && [ -d "$LAUNCH_DIR" ]; then
+    local f label dir sched header=0
+    for f in "$LAUNCH_DIR"/com.compass.schedule.*.plist; do
+      [ -f "$f" ] || continue
+      found=1
+      [ "$header" = 1 ] || { printf 'compass-managed schedule (launchd):\n'; header=1; }
+      label="$(basename "$f" .plist)"
+      dir="$(sed -n 's/.*cd &quot;\([^&]*\)&quot;.*/\1/p; s/.*cd "\([^"]*\)".*/\1/p' "$f" | head -1)"
+      sched="$(grep -o '<dict>.*</dict>' "$f" | sed -e 's/<[^>]*>/ /g' -e 's/   */ /g' -e 's/^ //' -e 's/ $//' | tr '\n' ';' | sed 's/;$//')"
+      printf '%s  [%s]  %s\n' "$label" "$sched" "$dir"
+    done
+  fi
+
+  [ "$found" = 1 ] || printf 'no compass-managed schedule entries\n'
 }
 
 # ---------------------------------------------------------------------------
 # Subcommand: remove
 # ---------------------------------------------------------------------------
 cmd_remove() {
-  local routine="${1:-}"
+  local routine="" dir=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --dir)
+        [ $# -ge 2 ] || die "--dir requires a directory argument"
+        dir="$2"; shift 2
+        ;;
+      -*)  die "unknown flag '$1'" ;;
+      *)
+        [ -z "$routine" ] || die "unexpected argument '$1'"
+        routine="$1"; shift
+        ;;
+    esac
+  done
   [ -n "$routine" ] || die "remove requires a routine name"
   validate_routine "$routine"
+  # Resolve like add did, so the key matches (tolerate a since-deleted dir).
+  if [ -n "$dir" ] && [ -d "$dir" ]; then dir="$(cd "$dir" && pwd)"; fi
 
+  local removed=0
+
+  # crontab entries
   local tab; tab="$(read_crontab)"
   local outer; outer="$(outside_block "$tab")"
   local inner; inner="$(inside_block "$tab")"
-  local new_inner; new_inner="$(printf '%s\n' "$inner" | grep -v "# compass:${routine}$" || true)"
-
-  if [ "$inner" = "$new_inner" ]; then
-    printf 'no entry found for routine: %s\n' "$routine"
-    return 0
+  local new_inner; new_inner="$(printf '%s\n' "$inner" | strip_entries "$routine" "$dir")"
+  if [ "$inner" != "$new_inner" ]; then
+    install_crontab "$outer" "$new_inner"
+    printf 'removed (cron): %s%s\n' "$routine" "${dir:+  $dir}"
+    removed=1
   fi
 
-  install_crontab "$outer" "$new_inner"
-  printf 'removed: %s\n' "$routine"
+  # launchd agents (darwin)
+  if [ "$OS" = "Darwin" ] && [ -d "$LAUNCH_DIR" ]; then
+    local f
+    if [ -n "$dir" ]; then
+      f="$LAUNCH_DIR/$(plist_label "$routine" "$dir").plist"
+      if [ -f "$f" ]; then
+        launchd_remove "$f"
+        printf 'removed (launchd): %s  %s\n' "$routine" "$dir"
+        removed=1
+      fi
+    else
+      for f in "$LAUNCH_DIR/com.compass.schedule.$routine".*.plist; do
+        [ -f "$f" ] || continue
+        launchd_remove "$f"
+        printf 'removed (launchd): %s\n' "$(basename "$f" .plist)"
+        removed=1
+      done
+    fi
+  fi
+
+  if [ "$removed" = 0 ]; then
+    printf 'no entry found for routine: %s%s\n' "$routine" "${dir:+ (dir: $dir)}"
+    return 0
+  fi
+  [ -z "$dir" ] && note "no --dir given — removed ALL entries for '$routine' (use --dir DIR to remove just one repo's)"
+  return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -335,17 +559,19 @@ except Exception:
 }
 
 # ---------------------------------------------------------------------------
-# Entry point
+# Entry point (skipped when sourced — tests call the pure generators directly)
 # ---------------------------------------------------------------------------
-CMD="${1:-}"
-[ $# -gt 0 ] && shift
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  CMD="${1:-}"
+  [ $# -gt 0 ] && shift
 
-case "$CMD" in
-  add)       cmd_add    "$@" ;;
-  list)      cmd_list   "$@" ;;
-  remove)    cmd_remove "$@" ;;
-  run)       cmd_run    "$@" ;;
-  -h|--help) usage ;;
-  "")        usage; exit 1 ;;
-  *)         die "unknown subcommand '$CMD' (try --help)" ;;
-esac
+  case "$CMD" in
+    add)       cmd_add    "$@" ;;
+    list)      cmd_list   "$@" ;;
+    remove)    cmd_remove "$@" ;;
+    run)       cmd_run    "$@" ;;
+    -h|--help) usage ;;
+    "")        usage; exit 1 ;;
+    *)         die "unknown subcommand '$CMD' (try --help)" ;;
+  esac
+fi

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -289,6 +289,40 @@ if grep -q 'gh pr merge --squash <n>' "$ROOT/sdlc/routines/prompts/pr-shepherd.m
 if grep -q -- '--twice-daily' "$ROOT/scripts/compass-schedule.sh"; then
   ok "--twice-daily cadence flag exists"; else no "--twice-daily flag missing"; fi
 
+echo "compass-schedule — per-repo scheduling (--dir) + dry-run backends:"
+SCHED="$ROOT/scripts/compass-schedule.sh"
+SD1="$(cd "$(mktemp -d)" && pwd)"; SD2="$(cd "$(mktemp -d)" && pwd)"
+# pure generator: entry cds into --dir and the trailing comment key carries the dir
+SENT="$(bash -c '. "$1" && make_entry "0 6 * * *" pr-babysit "$2"' _ "$SCHED" "$SD1")"
+has "entry cds into --dir"          "$SENT" "cd \"$SD1\""
+has "entry comment key carries dir" "$SENT" "# compass:pr-babysit:$SD1"
+has "entry passes dir to run"       "$SENT" "schedule run \"pr-babysit\" \"$SD1\""
+# end-to-end under COMPASS_SCHEDULE_DRYRUN (--cron forces the crontab backend on every OS)
+COMPASS_SCHEDULE_DRYRUN=1 bash "$SCHED" add pr-babysit --cron "0 6 * * *" --dir "$SD1" >/dev/null 2>&1
+COMPASS_SCHEDULE_DRYRUN=1 bash "$SCHED" add pr-babysit --cron "0 7 * * *" --dir "$SD2" >/dev/null 2>&1
+SL1="$(COMPASS_SCHEDULE_DRYRUN=1 bash "$SCHED" list)"
+has "--dir persisted in entry text"      "$SL1" "cd \"$SD1\""
+has "same routine, two dirs coexist (1)" "$SL1" "# compass:pr-babysit:$SD1"
+has "same routine, two dirs coexist (2)" "$SL1" "# compass:pr-babysit:$SD2"
+COMPASS_SCHEDULE_DRYRUN=1 bash "$SCHED" remove pr-babysit --dir "$SD1" >/dev/null
+SL2="$(COMPASS_SCHEDULE_DRYRUN=1 bash "$SCHED" list)"
+case "$SL2" in *"compass:pr-babysit:$SD1"*) no "remove --dir should remove only that dir's entry" ;; *) ok "remove --dir removes only that dir" ;; esac
+has "the other dir's entry survives" "$SL2" "# compass:pr-babysit:$SD2"
+RALL="$(COMPASS_SCHEDULE_DRYRUN=1 bash "$SCHED" remove pr-babysit)"
+has "remove without --dir notes it removed all" "$RALL" "removed ALL entries"
+# darwin: launchd plist generation (dry-run — nothing is bootstrapped or installed)
+if [ "$(uname)" = "Darwin" ] && command -v plutil >/dev/null 2>&1; then
+  SADD="$(COMPASS_SCHEDULE_DRYRUN=1 bash "$SCHED" add pr-babysit --daily --dir "$SD1")"
+  has "darwin add says launchd catches up on wake" "$SADD" "once on wake"
+  PL="$(ls "$TMP"/dryrun-launchagents/com.compass.schedule.pr-babysit.*.plist 2>/dev/null | head -1)"
+  if [ -n "$PL" ] && plutil -lint "$PL" >/dev/null 2>&1; then ok "generated launchd plist is valid (plutil -lint)"; else no "launchd plist missing or invalid"; fi
+  has "plist cds into --dir"           "$(cat "$PL" 2>/dev/null)" "cd \"$SD1\""
+  has "list shows launchd entry + dir" "$(COMPASS_SCHEDULE_DRYRUN=1 bash "$SCHED" list)" "com.compass.schedule.pr-babysit"
+  COMPASS_SCHEDULE_DRYRUN=1 bash "$SCHED" remove pr-babysit --dir "$SD1" >/dev/null
+  if [ -f "$PL" ]; then no "remove --dir left the plist behind"; else ok "remove --dir deletes the plist"; fi
+else ok "non-darwin (or no plutil) — skipping launchd plist tests"; fi
+rm -rf "$SD1" "$SD2" "$TMP/dryrun-crontab" "$TMP/dryrun-launchagents"
+
 echo "new-repo — a dangling AGENTS.md symlink does not abort (set -e):"
 if command -v git >/dev/null 2>&1; then
   NR="$(mktemp -d)"


### PR DESCRIPTION
Fixes both scheduling caveats:

1. **Per-repo scheduling** — entries hard-cd'd into the compass repo itself; `add`/`remove` now take `--dir` (default $PWD), the entry key carries the dir so the same routine coexists across repos, scoped remove works, dir-less legacy entries still removable.
2. **Sleep-proof cadence** — on macOS, cadence flags now write launchd agents (`StartCalendarInterval` runs a slept-through slot once on wake) instead of crontab (which silently skips). `--cron` expressions stay on crontab with an explicit warning. Backends are self-healing — an add in one strips the same routine+dir from the other, so nothing double-fires.

Enables `compass enable --schedule` (#90) to bind pr-shepherd per target repo.

## Verification (re-run by the driver)
CLI tests **158/0** (new: pure-generator assertions, two-dir coexistence, scoped remove, plutil-linted plist) · shellcheck error-level clean · doctor 143 ok/0 · manual smoke: two dirs coexist, scoped remove leaves the sibling