### PR TITLE
fix(enable): bash-3.2 local-expansion bug on the owner/repo clone path

### DIFF
--- a/scripts/compass-enable.sh
+++ b/scripts/compass-enable.sh
@@ -52,7 +52,10 @@ resolve_dir() {
   if [ -d "$t" ]; then (cd "$t" && pwd); return 0; fi
   case "$t" in
     */*)
-      local name="${t##*/}" dest="$CLONE_ROOT/$name"
+      # Two statements on purpose: bash 3.2 expands a `local` line's args before
+      # assigning any of them, so $name in dest would be unbound under set -u.
+      local name dest
+      name="${t##*/}"; dest="$CLONE_ROOT/$name"
       mkdir -p "$CLONE_ROOT"
       if [ -d "$dest/.git" ]; then printf '%s' "$dest"; return 0; fi
       [ "$DRYRUN" = 1 ] && { printf '%s' "$dest"; return 0; }

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -272,6 +272,11 @@ has "dry-run prints the layered plan"    "$EOUT" "L1 new-repo.sh"
 has "dry-run includes schedule step"     "$EOUT" "pr-shepherd twice daily"
 has "dry-run includes coverage step"     "$EOUT" "coverage≥70"
 [ -z "$(git -C "$ETMP/fake-repo" status --porcelain)" ] && ok "dry-run changed nothing" || no "dry-run mutated the repo"
+# owner/repo slug path (the clone branch) must resolve in dry-run — caught a live
+# bash-3.2 `local` expansion bug the dir path never exercises.
+SOUT="$("$EN" --dry-run --clone-root "$ETMP/clones" owner/some-repo 2>&1)"; SRC=$?
+eq  "slug dry-run exits 0"        "$SRC" 0
+has "slug target resolves"        "$SOUT" "enable:"
 rm -rf "$ETMP"
 grep -q "env-only" "$EN" && grep -q "never prompts" "$EN" \
   && ok "secrets are env-only by contract (no prompting, no credential-store reads)" \


### PR DESCRIPTION
`local name=X dest=$CLONE_ROOT/$name` — bash 3.2 (macOS) expands every arg of a `local` statement before assigning any, so `$name` is unbound under `set -u`. Only the clone path exercises it; found live enabling `dshakes/distil`. Split into two statements; slug dry-run path now tested.

Verified individually: CLI tests **171/0** · shellcheck error-level clean.