### PR TITLE
docs: compass enable, Gemini gate design, per-repo scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,13 @@ git checkout "$(git describe --tags --abbrev=0)"   # optional: pin to the latest
 
 **🛠️ By hand:** `make dry-run` (preview) → `make install` → `make doctor`. → [Team rollout](docs/05-plugin.md)
 
+**🚀 Put your other repos on it — one command each (or a list):**
+```bash
+compass enable --schedule owner/repo ~/code/another-repo   # config + PR gates + secrets-from-env
+                                                           # + required-checks ruleset + auto-merge
+                                                           # + twice-daily pr-shepherd (--dry-run to preview)
+```
+
 > **What install actually does:** replaces your global `~/.claude` config (settings, `CLAUDE.md`, agents, skills, hooks…) with symlinks into the repo — so `git pull`/`brew upgrade` updates everything. Anything it replaces is **backed up first** to `~/.claude/backups/`; `--copy` copies instead of linking; `make uninstall` removes only what it added. Personal overrides (your model, plugins, UI prefs) live in `claude/settings.local.json` — gitignored, deep-merged at install, so your prefs never fight the shipped defaults.
 
 ### One config, every agent

--- a/docs/09-sdlc.md
+++ b/docs/09-sdlc.md
@@ -15,6 +15,7 @@ both participate, so reviews get an independent cross-tool second opinion.
 issue ─▶ Planner ─▶ Builder ─▶ [PR] ─▶ Reviewer ⇄ Builder (auto-fix loop)
         (Claude)   (Claude)              (Claude)
                                          Auditor  (Codex, open only)
+                                         Auditor  (Gemini, open only — 3rd model)
                                          Security (Claude opus, open only)
                                          QA       (tests, every push)
                                               │
@@ -337,3 +338,20 @@ target repo's `.gitignore` — run artifacts are local scratch.
 > Reality check: the *plumbing* (issues, PRs, labels, Actions, required reviews) is
 > proven. "Fully autonomous swarm ships to prod unattended" is not reliable. compass
 > keeps humans on merge/deploy on purpose.
+
+
+## The Gemini auditor's security design (third cross-model gate)
+
+`sdlc-audit-gemini.yml` runs a third, independent model over every PR. Its wrapper action
+hardcodes auto-approval (`--yolo`), and Gemini CLI 0.52+ workspace-trust would extend that
+approval to PR-controlled files — so the workflow is deliberately shaped so neither matters:
+
+- **Trusted-base checkout** — the workspace is the base branch's tree, never the PR's; a
+  hostile PR cannot plant `.gemini/` config or `GEMINI.md` context for the agent.
+- **Diff as data** — the PR's changes arrive only as `pr-diff.patch`, fetched from the merge
+  ref and read as a file. The prompt marks it untrusted.
+- **Read-only tool allowlist** — the action's `settings` restrict core tools to
+  read/list/glob/grep; there is no shell, write, or network tool for auto-approval to approve.
+
+Skips cleanly when `GEMINI_API_KEY` is absent and for Dependabot-actor runs. This design
+survived two rounds of Codex cross-audit blocking findings before landing (#93).

--- a/docs/11-using-compass.md
+++ b/docs/11-using-compass.md
@@ -13,6 +13,7 @@ habits that make you fast and cheap. If you read one doc, read this one.
 | It everywhere, steps by hand | `… && make dry-run && make install && make doctor` | same, three explicit steps |
 | Just the machinery, no global config | `/plugin marketplace add dshakes/compass && /plugin install compass@compass` | per-session plugin (no memory/permissions) |
 | Committed config in **one** repo | `make new-repo DIR=~/code/my-repo` | starter `CLAUDE.md` + `AGENTS.md` symlink |
+| A repo (or many) fully onboarded — config, PR gates, ruleset, auto-merge, scheduled shepherd | `compass enable [--schedule] [--coverage N] [--dry-run] <owner/repo|dir> ...` | the one-command onboarding; secrets from exported env only |
 | Committed config across **many** repos | `make apply-many DIRS="~/code/*"` *(or `scripts/apply-repos.sh --git-only ~/code/*`)* | the per-repo pieces, in every repo at once |
 | The team to get it on a repo | `make new-repo DIR=~/code/my-repo TEAM=1` | pins `compass@compass` in `.claude/settings.json` |
 

--- a/docs/20-loops.md
+++ b/docs/20-loops.md
@@ -35,7 +35,7 @@ place. compass has a primitive for each:
 | **Handoff** | hand each task off, isolated | a git **worktree** per task ([dynamic workflows](13-workflows.md) take `isolation:'worktree'`; the SDLC loop uses a branch/PR); once a PR exists, the [`pr-shepherd`](../claude/skills/pr-shepherd/SKILL.md) skill carries it to the merge gate |
 | **Verification** | the move that can say **no** | an **evaluator subagent** ([code-reviewer](12-every-agent.md) / [reviewer role](09-sdlc.md)) — assumes broken, runs it |
 | **Persistence** | state that survives the conversation | a **state file** (`state/triage.md` / a pinned tracking issue) + [Serena memory](04-mcp.md) |
-| **Scheduling** | make it turn again, on its own | a **cloud routine** (`sdlc/routines/*.yml`) or local [`compass schedule`](11-using-compass.md) |
+| **Scheduling** | make it turn again, on its own | a **cloud routine** (`sdlc/routines/*.yml`) or local [`compass schedule`](11-using-compass.md) — per-repo via `--dir`; on macOS it uses launchd, so a slept-through slot runs once on wake |
 
 One loop needs no schedule at all: **CI auto-fix** ([`sdlc-ci-fix.yml`](09-sdlc.md)) turns the
 moment a check suite goes red — PR failures feed the existing fix loop (round-capped), a


### PR DESCRIPTION
Docs catch-up for the last batch of shipped features:
- README + docs/11: `compass enable` one-command multi-repo onboarding
- docs/09: the Gemini third auditor in the diagram + its security design (trusted-base workspace, diff-as-data, read-only allowlist — the #93 hardening)
- docs/20: scheduling row reflects per-repo `--dir` + launchd wake catch-up

Verification: doctor 144 ok/0.