### PR TITLE
chore(release): pin v2.1.0 in the Homebrew formula + fix release.sh

### DIFF
--- a/Formula/compass.rb
+++ b/Formula/compass.rb
@@ -8,8 +8,8 @@
 class Compass < Formula
   desc "Measured guardrails, a budget cap, and a self-fixing loop for AI coding agents"
   homepage "https://github.com/dshakes/compass"
-  url "https://github.com/dshakes/compass/archive/refs/tags/v2.0.0.tar.gz"
-  sha256 "834f04e96c098084077543d5d774946fdcb94c130923921ab22d26e6177c009b"
+  url "https://github.com/dshakes/compass/archive/refs/tags/v2.1.0.tar.gz"
+  sha256 "afc8ad7837d422f53c7bc93a7b12cbaf564b55723eb4d8e1169b747f50be859e"
   license "MIT"
   head "https://github.com/dshakes/compass.git", branch: "main"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -83,6 +83,9 @@ if [ -n "$(git ls-remote --tags origin "$VER" 2>/dev/null)" ]; then echo "  tag 
 elif confirm_push "tag $VER"; then do_or_show git push origin "$VER"; fi
 
 # ── 2 · Homebrew formula: bump url + tarball sha ──────────────────────────────────
+# Nothing in this step may abort the run. The GitHub Release (step 3) is the
+# user-visible half of a release; a failure to pin a package manager's formula must
+# never leave a published tag without its Release page. See the v2.1.0 note below.
 say "2 · Homebrew formula"
 if ! command -v curl >/dev/null; then echo "  ! curl missing — bump Formula/compass.rb by hand"
 else
@@ -98,8 +101,31 @@ else
     if git diff --quiet Formula/compass.rb; then echo "  formula already at $VER / $sha"
     else
       do_or_show git commit -q -m "chore(release): pin $VER + tarball sha in the Homebrew formula" Formula/compass.rb
-      if confirm_push "main (formula bump)"; then do_or_show git push origin main; fi
-      echo "  formula → $VER  sha256 $sha"
+      # main is protected by a ruleset requiring status checks, so pushing the bump
+      # straight to it is rejected (GH013) — as it should be; that gate is the product.
+      # Route the formula bump through a PR like any other change.
+      #
+      # Found on v2.1.0: the tag went out, this push was declined, the script exited
+      # non-zero, and step 3 never ran — leaving a public tag with no Release page.
+      # Hence both fixes: a PR here, and step 3 no longer depends on this succeeding.
+      pinbranch="chore/homebrew-pin-$VER"
+      # Every fallible call sits in an `if` so `set -e` cannot abort the run here.
+      if confirm_push "$pinbranch (formula bump, via PR)"; then
+        if do_or_show git push -q origin "HEAD:refs/heads/$pinbranch"; then
+          if ! command -v gh >/dev/null; then
+            echo "  gh missing — open a PR from $pinbranch by hand"
+          elif do_or_show gh pr create --head "$pinbranch" \
+                 --title "chore(release): pin $VER in the Homebrew formula" \
+                 --body "Pins the Homebrew formula to the \`$VER\` tarball and its sha256. Cut by scripts/release.sh — main is protected, so the bump lands via PR."; then
+            echo "  formula → $VER  sha256 $sha  (PR opened from $pinbranch)"
+          else
+            echo "  ! PR not opened — branch $pinbranch is pushed; open it by hand"
+          fi
+        else
+          echo "  ! could not push $pinbranch — pin Formula/compass.rb by hand."
+          echo "    The GitHub Release below still publishes; a formula miss must not block it."
+        fi
+      fi
     fi
   else
     echo "  (dry-run or tag not yet on remote) — sha computed from $TARBALL after the tag is pushed"


### PR DESCRIPTION
Follow-up to the **v2.1.0** release. The tag and GitHub Release are already live and the SLSA attestation verifies (`compass verify v2.1.0` → ✓). This lands the two things that could not.

## 1. The Homebrew formula pin

`Formula/compass.rb` pinned to the `v2.1.0` tarball and its sha256. `release.sh` originally tried to push this straight to `main` and was **rejected with GH013** — main's ruleset requires status checks.

That rejection was correct. The gate is the product; the release script was the thing in the wrong.

## 2. Two defects in `release.sh`, found by cutting a real release

**Step 2 pushed directly to `main`.** Now commits to a branch and opens a PR, like any other change.

**`set -euo pipefail` turned that failure into a worse one.** The rejected push aborted the script, so **step 3 never ran** — leaving a public tag with a verified attestation and *no Release page*. Silent unless you looked.

Every fallible call in step 2 now sits inside an `if`, so a formula miss degrades to a printed next-step. **A package-manager pin failing must never cost the user-visible half of a release.**

## Verified

```
bash -n + shellcheck -S error   clean
release.sh --dry-run            idempotent — sees the existing tag and Release,
                                offers only to refresh the notes
compass verify v2.1.0           ✓ provenance verified
```

Ordinary PR — no rush, and nothing about v2.1.0 depends on it beyond `brew` users getting the new version.