### PR TITLE
feat(cli): compass version + compass upgrade; fix mirror drift for good

### DIFF
--- a/.github/workflows/sync-mirrors.yml
+++ b/.github/workflows/sync-mirrors.yml
@@ -1,0 +1,80 @@
+# Mirror auto-sync — keeps sdlc/workflows/*.yml byte-identical to their .github/workflows/
+# counterparts on Dependabot PRs.
+#
+# WHY THIS EXISTS. Dependabot can only see .github/workflows/, but check-actions.sh
+# requires the sdlc/workflows/ templates to be identical mirrors. So every weekly bump
+# touching an sdlc-* workflow lands in one copy, fails `validate` on drift, and needs a
+# human to sync by hand. This does that one mechanical step.
+#
+# SCOPE, DELIBERATELY NARROW. Runs only for the dependabot actor, only on same-repo PRs,
+# commits only paths under sdlc/workflows/, and holds contents:write and nothing else.
+# It is a `pull_request` trigger (not pull_request_target), so it never runs privileged
+# against untrusted code — the write capability comes from the App token, which is minted
+# only after the actor check has already passed.
+name: "ci · sync workflow mirrors"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/sdlc-*.yml"
+      - ".github/workflows/release.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-mirrors-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    # Dependabot only. A human editing .github/workflows/ directly should get the failing
+    # drift check and decide for themselves which side is canonical — that is a real
+    # review question, not a mechanical one.
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Sync mirrors in the direction the change came from
+        id: sync
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main
+          bash scripts/check-actions.sh --fix
+          if git diff --quiet -- sdlc/workflows/; then
+            echo "changed=false" >>"$GITHUB_OUTPUT"
+            echo "mirrors already in sync"
+          else
+            echo "changed=true" >>"$GITHUB_OUTPUT"
+            git diff --stat -- sdlc/workflows/
+          fi
+
+      # Commit ONLY the template mirrors. If --fix ever touched anything else, the add
+      # below silently drops it and the drift check still fails — loud, not silent.
+      - name: Commit and push the sync
+        if: steps.sync.outputs.changed == 'true'
+        # HEAD_REF goes through env, never interpolated into the script body. A branch name
+        # is attacker-influenced input, and `${{ }}` inside a run: block is the classic
+        # Actions RCE — the very pattern scripts/check-actions.sh gates on. It caught this
+        # workflow's first draft, which is the gate doing its job on its own author.
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          git config user.name  "compass-sdlc-bot"
+          git config user.email "compass-sdlc-bot@users.noreply.github.com"
+          git add -- sdlc/workflows/
+          git commit -m "ci: sync sdlc/workflows mirrors with the action bump
+
+          Dependabot only sees .github/workflows/; check-actions.sh requires the
+          templates to match. Synced automatically by sync-mirrors.yml."
+          git push origin "HEAD:refs/heads/$HEAD_REF"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **`compass version`** (also `--version` / `-v`) — prints version, install kind
+  (git clone / homebrew / packaged), location and commit. It did not exist; it is the
+  first thing anyone types in a bug report.
+- **`compass upgrade`** (`--check` / `--yes`) — updates the install in place, detecting
+  how compass was installed. compass is not a pip/pipx/npm package, so `pipx upgrade
+  compass` fails with "Package is not installed"; this routes git clones through
+  `git pull --ff-only` + `install.sh`, defers Homebrew installs to `brew upgrade compass`,
+  and names the plugin command for plugin installs. Refuses on a dirty tree rather than
+  clobbering local config.
+- **`scripts/check-actions.sh --fix`** + **`ci · sync workflow mirrors`** — repairs
+  `.github/workflows` ↔ `sdlc/workflows` mirror drift *in the direction the change came
+  from*, and does it automatically on Dependabot PRs.
+
+### Fixed
+
+- **The drift hint told you to discard security updates.** It always printed
+  `cp sdlc/workflows/X .github/workflows/` — template → live. Dependabot only edits the
+  **live** copy, so following that advice reverted the bump. `--fix` now picks the source
+  by asking git which side actually moved, and refuses when both did.
+
 ## [2.1.0] - 2026-07-27
 
 ### Added

--- a/bin/compass
+++ b/bin/compass
@@ -58,6 +58,9 @@ usage: compass <command> [args]
   bench   [--guardrail|--router|--json]
                            Reproducible scorecard: guardrail precision/recall + router
                            accuracy (deterministic, CI-gated). --sdlc <dir> for fix-rate.
+  upgrade [--check|--yes]  Update this install in place. Detects how compass was
+                           installed (git clone / Homebrew / plugin) and does the right
+                           thing — compass is not a pip or npm package.
   ablate  [--detector NAME|--json|--gate]
                            Ablation study: remove each policy rule in turn, re-score it
                            against the corpus that covers it, and report load-bearing /
@@ -101,6 +104,7 @@ usage: compass <command> [args]
   audit-log [--since D] [-n N] [--json]
                            The security trail: every blocked footgun (secret write,
                            dangerous command, scan hit) as a queryable JSONL record.
+  version                  Print the installed version, install kind, and location.
   doctor                   Validate the compass install (make doctor).
   release [vX.Y.Z|--dry-run]
                            Finish a release: push the tag, pin the Homebrew sha, publish the
@@ -126,6 +130,7 @@ case "$cmd" in
   schedule) run schedule "$@" ;;
   route)    run route "$@" ;;
   bench)    run bench "$@" ;;
+  upgrade) run upgrade "$@" ;;
   ablate)   run ablate "$@" ;;
   policy-synth) run policy-synth "$@" ;;
   sbom)     run sbom "$@" ;;
@@ -141,6 +146,17 @@ case "$cmd" in
   audit-log) run audit-log "$@" ;;
   doctor)   exec "$SCRIPTS/doctor.sh" "$@" ;;
   release)  exec "$SCRIPTS/release.sh" "$@" ;;
+  # `compass version` is table stakes: it is the first thing anyone types in a bug report,
+  # and every spelling of it should work. The version of record is the plugin manifest —
+  # the same value the release bumps — so this can never drift from what was shipped.
+  version|--version|-v)
+    v="$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' "$ROOT/plugins/core/.claude-plugin/plugin.json" 2>/dev/null | head -1)"
+    kind="git clone"
+    [ -d "$ROOT/.git" ] || kind="packaged"
+    case "$ROOT" in *"/Cellar/compass/"*) kind="homebrew" ;; esac
+    printf 'compass %s (%s)\n%s\n' "${v:-unknown}" "$kind" "$ROOT"
+    [ -d "$ROOT/.git" ] && printf 'commit  %s\n' "$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo '?')"
+    exit 0 ;;
   -h|--help|help) usage ;;
   *) echo "compass: unknown command '$cmd'" >&2; echo; usage; exit 2 ;;
 esac

--- a/scripts/check-actions.sh
+++ b/scripts/check-actions.sh
@@ -16,9 +16,45 @@
 # Usage:
 #   check-actions.sh                 # full repo audit (CI)
 #   check-actions.sh --lint <file…>  # per-file lint only (used by fixtures to prove the gate bites)
+#   check-actions.sh --fix           # repair mirror drift, copying in the correct direction
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ── --fix: repair mirror drift, in the direction the change actually came from ────
+# The naive fix is `cp sdlc/workflows/X .github/workflows/` — templates are the canonical
+# source, so that is right for a hand-edited template. It is exactly WRONG for a
+# Dependabot bump: Dependabot can only see .github/workflows/, so the LIVE copy holds the
+# new SHA and the template is the stale one. Blindly copying template→live there reverts
+# a security update, and the old drift message told you to do precisely that.
+#
+# So pick the source by asking git which side actually moved, relative to the merge base
+# with origin/main. Whichever file differs from the base is the edit; the other is stale.
+fix_mirrors() {
+  local base_ref tmpl base live t_ch l_ch fixed=0
+  base_ref="$(git -C "$ROOT" merge-base HEAD origin/main 2>/dev/null || echo HEAD)"
+  for tmpl in "$ROOT"/sdlc/workflows/*.yml; do
+    base="$(basename "$tmpl")"; live="$ROOT/.github/workflows/$base"
+    [ -f "$live" ] || continue
+    diff -q "$tmpl" "$live" >/dev/null 2>&1 && continue
+
+    git -C "$ROOT" diff --quiet "$base_ref" -- "sdlc/workflows/$base"      2>/dev/null && t_ch=0 || t_ch=1
+    git -C "$ROOT" diff --quiet "$base_ref" -- ".github/workflows/$base"   2>/dev/null && l_ch=0 || l_ch=1
+
+    if   [ "$t_ch" = 1 ] && [ "$l_ch" = 0 ]; then cp -f "$tmpl" "$live"; echo "  synced template → live: $base"
+    elif [ "$l_ch" = 1 ] && [ "$t_ch" = 0 ]; then cp -f "$live" "$tmpl"; echo "  synced live → template: $base"
+    else
+      # Both moved (or neither did, and they still differ) — a human has to choose. Never
+      # guess here: picking wrong silently discards one side's change.
+      printf '  \033[31mFAIL\033[0m %s: both copies changed since %s — resolve by hand\n' "$base" "${base_ref:0:8}"
+      return 1
+    fi
+    fixed=$((fixed + 1))
+  done
+  [ "$fixed" -gt 0 ] && echo "  fixed $fixed mirror(s)" || echo "  no drift to fix"
+  return 0
+}
+if [ "${1:-}" = "--fix" ]; then fix_mirrors; exit $?; fi
 trap 'rm -f /tmp/_inj.$$' EXIT
 pass=0; fail=0
 ok() { printf '  \033[32mok\033[0m   %s\n' "$1"; pass=$((pass + 1)); }
@@ -67,7 +103,7 @@ for tmpl in "$ROOT"/sdlc/workflows/*.yml; do
   live="$ROOT/.github/workflows/$base"
   if [ ! -f "$live" ]; then no "missing dogfood copy: .github/workflows/$base"; continue; fi
   if diff -q "$tmpl" "$live" >/dev/null 2>&1; then ok "in sync: $base"
-  else no "DRIFT: .github/workflows/$base != sdlc/workflows/$base (run: cp sdlc/workflows/$base .github/workflows/)"; fi
+  else no "DRIFT: .github/workflows/$base != sdlc/workflows/$base (run: scripts/check-actions.sh --fix)"; fi
 done
 
 echo "least-privilege + pinning + injection — all workflows:"

--- a/scripts/compass-upgrade.sh
+++ b/scripts/compass-upgrade.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# compass-upgrade.sh — update the compass install in place, whichever way it was installed.
+#
+# compass is not a pip/pipx/npm package, so `pipx upgrade compass` (a reasonable guess)
+# fails with "Package is not installed". There are three real install shapes, and each
+# upgrades differently:
+#
+#   git clone + ./install.sh   git pull --ff-only, then re-run install.sh to refresh symlinks
+#   Homebrew                   brew upgrade compass — the tap owns the checkout, not us
+#   Claude Code plugin         /plugin marketplace update dshakes/compass, inside the agent
+#
+# This detects which one you have and does the right thing (or tells you the one command
+# that will), so nobody has to remember.
+#
+# Usage:
+#   compass upgrade            # detect, pull, reinstall, report the version change
+#   compass upgrade --check    # report only: what's installed, what's latest. Changes nothing.
+#   compass upgrade --yes      # skip the confirmation prompt
+set -uo pipefail
+
+ROOT="${COMPASS_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+CHECK=0; YES=0
+for a in "$@"; do case "$a" in
+  --check) CHECK=1 ;;
+  --yes|-y) YES=1 ;;
+  -h|--help) sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  *) printf 'unknown flag: %s\n' "$a" >&2; exit 2 ;;
+esac; done
+
+say()  { printf '\033[1;36m▶ %s\033[0m\n' "$1"; }
+note() { printf '  %s\n' "$1"; }
+warn() { printf '  \033[33m!\033[0m %s\n' "$1"; }
+
+current_version() {
+  # The plugin manifest is the version of record; fall back to the newest CHANGELOG heading.
+  local v=""
+  [ -f "$ROOT/plugins/core/.claude-plugin/plugin.json" ] &&
+    v="$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' "$ROOT/plugins/core/.claude-plugin/plugin.json" | head -1)"
+  [ -n "$v" ] || v="$(sed -n 's/^## \[\([0-9][^]]*\)\].*/\1/p' "$ROOT/CHANGELOG.md" 2>/dev/null | head -1)"
+  printf '%s' "${v:-unknown}"
+}
+
+latest_version() {
+  command -v gh >/dev/null || { printf ''; return; }
+  gh release view --repo dshakes/compass --json tagName --jq '.tagName' 2>/dev/null | sed 's/^v//'
+}
+
+# ── detect the install shape ─────────────────────────────────────────────────────
+# Homebrew first: a brew install sets COMPASS_REPO_ROOT into the Cellar, and the checkout
+# there is brew's to manage — pulling in it would fight the package manager.
+if [ -n "${HOMEBREW_PREFIX:-}" ] && case "$ROOT" in "$HOMEBREW_PREFIX"/*) true ;; *) false ;; esac; then
+  KIND=homebrew
+elif command -v brew >/dev/null 2>&1 && brew list compass >/dev/null 2>&1 &&
+     case "$ROOT" in *"/Cellar/compass/"*) true ;; *) false ;; esac; then
+  KIND=homebrew
+elif [ -d "$ROOT/.git" ]; then
+  KIND=git
+else
+  KIND=unknown
+fi
+
+cur="$(current_version)"; latest="$(latest_version)"
+say "compass upgrade"
+note "install:  $KIND"
+note "location: $ROOT"
+note "version:  $cur${latest:+   latest: $latest}"
+[ -n "$latest" ] || warn "could not reach GitHub for the latest version (gh missing or offline)"
+if [ -n "$latest" ] && [ "$cur" = "$latest" ]; then note "already up to date."; [ "$CHECK" = 1 ] && exit 0; fi
+
+case "$KIND" in
+  homebrew)
+    say "Homebrew install"
+    note "brew owns this checkout — upgrade with:"
+    note "    brew upgrade compass"
+    exit 0 ;;
+  unknown)
+    say "unrecognised install"
+    warn "$ROOT is not a git checkout and not under Homebrew."
+    note "If you installed the Claude Code plugin, update it from inside the agent:"
+    note "    /plugin marketplace update dshakes/compass"
+    note "Otherwise re-install:  git clone https://github.com/dshakes/compass ~/compass && cd ~/compass && ./quickstart.sh"
+    exit 1 ;;
+esac
+
+[ "$CHECK" = 1 ] && exit 0
+
+# ── git install: pull, then re-run install.sh ────────────────────────────────────
+# Refuse on a dirty tree. An upgrade that silently stashes or clobbers local edits is a
+# worse failure than not upgrading — the whole point of this repo is config you own.
+if [ -n "$(git -C "$ROOT" status --porcelain 2>/dev/null)" ]; then
+  warn "working tree has uncommitted changes — not touching it."
+  note "commit or stash them, then re-run. Nothing was changed."
+  exit 1
+fi
+
+branch="$(git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+[ "$branch" = "main" ] || warn "on branch '$branch', not main — pulling that branch."
+
+if [ "$YES" = 0 ]; then
+  printf '  pull %s and re-run install.sh? [y/N] ' "$branch"
+  read -r reply </dev/tty 2>/dev/null || reply=n
+  case "$reply" in y|Y|yes) ;; *) note "aborted — nothing changed."; exit 0 ;; esac
+fi
+
+say "1 · pull"
+if ! git -C "$ROOT" pull --ff-only 2>&1 | sed 's/^/  /'; then
+  warn "pull failed (diverged history, or no network)."
+  note "resolve by hand, e.g.  git -C $ROOT pull --rebase"
+  exit 1
+fi
+
+say "2 · reinstall (refresh symlinks + plugin)"
+if [ -x "$ROOT/install.sh" ]; then
+  "$ROOT/install.sh" 2>&1 | tail -5 | sed 's/^/  /'
+else
+  warn "install.sh not found or not executable — symlinks not refreshed."
+fi
+
+new="$(current_version)"
+say "done"
+if [ "$new" = "$cur" ]; then note "already at $new — nothing changed."
+else note "$cur → $new"; fi
+note "verify the release you're on:  compass verify v$new"


### PR DESCRIPTION
Three gaps, all found by using the CLI the way a user would rather than by reading it.

## `compass version`

Didn't exist. `version`, `--version`, `-v` all returned `unknown command`. It's the first thing anyone types in a bug report. Prints version, install kind, location, commit.

## `compass upgrade`

There was no upgrade path except "cd into the repo and `make update`". `pipx upgrade compass` — a reasonable guess — fails with *Package is not installed*, because compass isn't a pip/npm package.

Detects the install shape and does the right thing:

| Install | Action |
|---|---|
| git clone | `git pull --ff-only` + re-run `install.sh` |
| Homebrew | defers — `brew upgrade compass` (brew owns that checkout) |
| plugin / unknown | names the exact command instead of guessing |

**Refuses on a dirty tree.** An upgrade that silently stashes or clobbers local config is worse than not upgrading — this repo's whole premise is config you own.

## Mirror drift, fixed at the root

Dependabot only sees `.github/workflows/`, but `check-actions.sh` requires `sdlc/workflows/` to be byte-identical mirrors. Every weekly bump touching an `sdlc-*` workflow failed `validate` and needed a hand-sync.

**The old hint was actively harmful.** It always printed `cp sdlc/workflows/X .github/workflows/` — template → live. Dependabot edits the **live** copy, so following that advice *reverted the security bump*. Verified both directions:

```
simulate dependabot (live edited)  → synced live → template, bump preserved in both
simulate hand-edit (template)      → synced template → live
both sides changed                 → refuses, exits 1, asks a human
```

`--fix` picks the source by asking git which side moved relative to the merge base. `sync-mirrors.yml` then does it automatically on Dependabot PRs — that actor only, same-repo only, `contents: write` only, committing nothing outside `sdlc/workflows/`.

> Its first draft interpolated `github.event.pull_request.head.ref` directly into a `run:` block — the classic Actions RCE. `check-actions.sh` caught it before it left my machine. Now passed via `env:`. Worth noting the gate bit its own author.

## Verified

```
actions audit 17/17 · docs audit 4/4 · doctor ok
actionlint (CI severity) clean · shellcheck -S error clean
compass version / --version / -v   → 2.1.0 (git clone) + commit
compass upgrade --check            → detects git install, compares to latest release
compass upgrade (dirty tree)       → refuses, exit 1, nothing changed
COMPASS_REPO_ROOT=…/Cellar/…       → detects homebrew, defers to brew
```