### PR TITLE
release: 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-07-27
+
 ### Added
 
 - **`compass version`** (also `--version` / `-v`) — prints version, install kind

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "compass",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "compass — one operating manual + eval-gated guardrails, red-team hardening, a cost-tier router and signed config for your coding agent. Loads the manual as GEMINI.md and wires the same version-pinned MCP servers (context7 · fetch · git) compass uses for Claude Code and Codex.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {

--- a/plugins/core-lsp/.claude-plugin/plugin.json
+++ b/plugins/core-lsp/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "core-lsp",
   "displayName": "compass — LSP",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Language-server intelligence (diagnostics, navigation) for Go, Rust, TypeScript, and Python. Opt-in companion to core — requires the language servers installed on PATH.",
   "author": {
     "name": "Shekhar Mudarapu",

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "compass",
   "displayName": "compass",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Cost-tiered specialist subagents, workflow commands, guardrail + live-budget-ceiling + auto-quality hooks, a repo-bootstrap skill, a terse output style, and parity MCP servers — for serious polyglot software work.",
   "author": {
     "name": "Shekhar Mudarapu",

--- a/plugins/core/.codex-plugin/plugin.json
+++ b/plugins/core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Cost-tiered specialist subagents, workflow commands, guardrail + red-team + auto-quality hooks, repo-bootstrap and using-compass skills, and parity MCP servers — for serious polyglot software work.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",


### PR DESCRIPTION
Cuts **2.2.0**. Version bumped across all four manifests; CHANGELOG section closed.

Contents (already merged, this just cuts the version):

- **`compass version`** / `--version` / `-v` — didn't exist before.
- **`compass upgrade`** — no upgrade path existed except `cd` into the repo. `pipx upgrade compass` fails because compass isn't a pip package; this detects git clone / Homebrew / plugin and does the right thing. Refuses on a dirty tree.
- **Mirror drift fixed at the root** — `check-actions.sh --fix` syncs in the direction the change came from, and `sync-mirrors.yml` does it automatically on Dependabot PRs. The old hint told you to copy template→live, which *reverted* Dependabot's security bumps.

Verified on this branch: `compass version` → 2.2.0, actions 17/17, docs 4/4, doctor ok.