### PR TITLE
fix(enable): dry-run must check repo secrets, not just my shell

### DIFF
--- a/scripts/compass-enable.sh
+++ b/scripts/compass-enable.sh
@@ -138,16 +138,32 @@ enable_one() {
     if [ -d "$dir/.git" ]; then note "checkout: $dir (exists)"
     else                        note "checkout: $dir (would clone here)"; fi
 
-    # The load-bearing part: which of the five will actually be set.
+    # The load-bearing part: what the agent jobs will ACTUALLY have to work with.
+    #
+    # Reporting only "is it in my shell?" is a lie by omission: a secret already set on
+    # the repo (by hand, or by an earlier run) needs nothing from your env, and calling
+    # it MISSING sends you hunting for a key that is sitting there. Ask the repo too, and
+    # report the three states separately. Names only — `gh secret list` cannot return
+    # values, and nothing here reads one.
+    local repo_secrets="" n_onrepo=0
+    [ -n "$plan_nwo" ] && repo_secrets="$(gh secret list --repo "$plan_nwo" --json name --jq '.[].name' 2>/dev/null || true)"
+
     for s in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY CLAUDE_CODE_OAUTH_TOKEN SDLC_BOT_TOKEN; do
-      if [ -n "${!s:-}" ]; then n_set=$((n_set + 1)); else n_missing=$((n_missing + 1)); fi
+      if [ -n "${!s:-}" ]; then n_set=$((n_set + 1))
+      elif printf '%s\n' "$repo_secrets" | grep -qx "$s"; then n_onrepo=$((n_onrepo + 1))
+      else n_missing=$((n_missing + 1)); fi
     done
-    note "secrets:  $n_set of 5 exported and would be set; $n_missing missing"
+    note "secrets:  $n_set from env · $n_onrepo already on repo · $n_missing missing"
     for s in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY CLAUDE_CODE_OAUTH_TOKEN SDLC_BOT_TOKEN; do
-      if [ -n "${!s:-}" ]; then note "            set      $s"
-      else                       note "            MISSING  $s"; fi
+      if [ -n "${!s:-}" ]; then
+        # env wins on a real run — enable always sets when the var is exported.
+        if printf '%s\n' "$repo_secrets" | grep -qx "$s"; then note "            from env $s  (overwrites the one on the repo)"
+        else                                                    note "            from env $s"; fi
+      elif printf '%s\n' "$repo_secrets" | grep -qx "$s"; then   note "            on repo  $s  (kept as-is)"
+      else                                                       note "            MISSING  $s"; fi
     done
     [ "$n_missing" -gt 0 ] && note "          missing ones are skipped silently on a real run — agent jobs no-op green until set"
+    [ "$n_missing" -eq 0 ] && [ "$n_set" -eq 0 ] && note "          nothing to set — the repo already has all five"
 
     # Name the scripts, not just the layers: "L1 new-repo.sh" tells you what to read if
     # you want to know exactly what it will do. test-cli.sh asserts on this, correctly.


### PR DESCRIPTION
The dry-run told me this about `dshakes/clickllm`:

```
secrets:  0 of 5 exported and would be set; 5 missing
          missing ones are skipped silently on a real run — agent jobs no-op green until set
```

Every one of those five was **already set on the repo**. It only ever inspected the local shell, so a secret sitting on the repo read as `MISSING` — sending you to hunt for a key that was already there.

Same failure class as the reachability bug in the previous commit: **a diagnostic that confidently reports something false is worse than one that says nothing.** Two of them in the same command in one day.

## Three states now

| Label | Meaning |
|---|---|
| `from env` | will be set from your environment (flags when it overwrites one already on the repo) |
| `on repo` | already set — `enable` leaves it alone |
| `MISSING` | neither — **this** is the one that no-ops your agent jobs |

`env` wins where both are present, matching what a real run does: `enable` only calls `gh secret set` when the var is exported.

Names only — `gh secret list` cannot return values, and nothing here reads one.

## Verified against live repos

```
clickllm                    0 from env · 5 already on repo · 0 missing
clickllm + 1 var exported   1 from env (overwrites the one on the repo) · 4 on repo
compass-loop-demo           0 from env · 3 already on repo · 2 missing   ← mixed case
```

`cli tests 171 passed, 0 failed · actions 17/17 · docs 4/4 · doctor ok · shellcheck -S error clean`