### PR TITLE
fix(sdlc): audit every push, not just the first commit

### DIFF
--- a/.github/workflows/sdlc-audit-gemini.yml
+++ b/.github/workflows/sdlc-audit-gemini.yml
@@ -30,6 +30,9 @@ jobs:
       && (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
       && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
     runs-on: ubuntu-latest
+    concurrency:
+      group: sdlc-audit-gemini-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       # Secrets aren't readable in a job-level `if`, so gate every later step on this
       # first step's output — absent key means the job completes green as a no-op.

--- a/.github/workflows/sdlc-audit-gemini.yml
+++ b/.github/workflows/sdlc-audit-gemini.yml
@@ -7,7 +7,7 @@ name: "sdlc · audit (Gemini)"
 
 on:
   pull_request:
-    types: [opened, reopened, labeled]
+    types: [opened, reopened, synchronize, labeled]
 
 permissions:
   contents: read
@@ -17,7 +17,18 @@ jobs:
   audit-gemini:
     # Auto on open/reopen, or on the agent:audit label. (label.name is null on open events.)
     # dependabot-actor runs get Dependabot's (empty) secret store — agent can't auth, so skip
-    if: github.actor != 'dependabot[bot]' && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
+    # 1. dependabot never audits — those runs get Dependabot's (empty) secret store,
+    #    so the agent cannot authenticate at all. Capability, not cost.
+    # 2. On `synchronize` only, bot pushes are skipped: the fix loop commits once per
+    #    round and auditing each re-spends credits for no added signal. Scoped to
+    #    synchronize deliberately — a blanket bot exclusion would also stop auditing
+    #    PRs *opened* by Renovate, Copilot and release bots.
+    # 3. A label triggers an audit only when it is `agent:audit` (label.name is null
+    #    on open events, hence the action check first).
+    if: >-
+      github.actor != 'dependabot[bot]'
+      && (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
+      && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
     runs-on: ubuntu-latest
     steps:
       # Secrets aren't readable in a job-level `if`, so gate every later step on this

--- a/.github/workflows/sdlc-audit.yml
+++ b/.github/workflows/sdlc-audit.yml
@@ -29,6 +29,9 @@ jobs:
       && (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
       && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
     runs-on: ubuntu-latest
+    concurrency:
+      group: sdlc-audit-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/sdlc-audit.yml
+++ b/.github/workflows/sdlc-audit.yml
@@ -6,7 +6,7 @@ name: "sdlc · audit (Codex)"
 
 on:
   pull_request:
-    types: [opened, reopened, labeled]
+    types: [opened, reopened, synchronize, labeled]
 
 permissions:
   contents: read
@@ -16,7 +16,18 @@ jobs:
   audit:
     # Auto on open/reopen, or on the agent:audit label. (label.name is null on open events.)
     # dependabot-actor runs get Dependabot's (empty) secret store — agent can't auth, so skip
-    if: github.actor != 'dependabot[bot]' && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
+    # 1. dependabot never audits — those runs get Dependabot's (empty) secret store,
+    #    so the agent cannot authenticate at all. Capability, not cost.
+    # 2. On `synchronize` only, bot pushes are skipped: the fix loop commits once per
+    #    round and auditing each re-spends credits for no added signal. Scoped to
+    #    synchronize deliberately — a blanket bot exclusion would also stop auditing
+    #    PRs *opened* by Renovate, Copilot and release bots.
+    # 3. A label triggers an audit only when it is `agent:audit` (label.name is null
+    #    on open events, hence the action check first).
+    if: >-
+      github.actor != 'dependabot[bot]'
+      && (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
+      && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/sdlc/workflows/sdlc-audit-gemini.yml
+++ b/sdlc/workflows/sdlc-audit-gemini.yml
@@ -30,6 +30,9 @@ jobs:
       && (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
       && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
     runs-on: ubuntu-latest
+    concurrency:
+      group: sdlc-audit-gemini-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       # Secrets aren't readable in a job-level `if`, so gate every later step on this
       # first step's output — absent key means the job completes green as a no-op.

--- a/sdlc/workflows/sdlc-audit-gemini.yml
+++ b/sdlc/workflows/sdlc-audit-gemini.yml
@@ -7,7 +7,7 @@ name: "sdlc · audit (Gemini)"
 
 on:
   pull_request:
-    types: [opened, reopened, labeled]
+    types: [opened, reopened, synchronize, labeled]
 
 permissions:
   contents: read
@@ -17,7 +17,18 @@ jobs:
   audit-gemini:
     # Auto on open/reopen, or on the agent:audit label. (label.name is null on open events.)
     # dependabot-actor runs get Dependabot's (empty) secret store — agent can't auth, so skip
-    if: github.actor != 'dependabot[bot]' && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
+    # 1. dependabot never audits — those runs get Dependabot's (empty) secret store,
+    #    so the agent cannot authenticate at all. Capability, not cost.
+    # 2. On `synchronize` only, bot pushes are skipped: the fix loop commits once per
+    #    round and auditing each re-spends credits for no added signal. Scoped to
+    #    synchronize deliberately — a blanket bot exclusion would also stop auditing
+    #    PRs *opened* by Renovate, Copilot and release bots.
+    # 3. A label triggers an audit only when it is `agent:audit` (label.name is null
+    #    on open events, hence the action check first).
+    if: >-
+      github.actor != 'dependabot[bot]'
+      && (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
+      && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
     runs-on: ubuntu-latest
     steps:
       # Secrets aren't readable in a job-level `if`, so gate every later step on this

--- a/sdlc/workflows/sdlc-audit.yml
+++ b/sdlc/workflows/sdlc-audit.yml
@@ -29,6 +29,9 @@ jobs:
       && (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
       && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
     runs-on: ubuntu-latest
+    concurrency:
+      group: sdlc-audit-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/sdlc/workflows/sdlc-audit.yml
+++ b/sdlc/workflows/sdlc-audit.yml
@@ -6,7 +6,7 @@ name: "sdlc · audit (Codex)"
 
 on:
   pull_request:
-    types: [opened, reopened, labeled]
+    types: [opened, reopened, synchronize, labeled]
 
 permissions:
   contents: read
@@ -16,7 +16,18 @@ jobs:
   audit:
     # Auto on open/reopen, or on the agent:audit label. (label.name is null on open events.)
     # dependabot-actor runs get Dependabot's (empty) secret store — agent can't auth, so skip
-    if: github.actor != 'dependabot[bot]' && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
+    # 1. dependabot never audits — those runs get Dependabot's (empty) secret store,
+    #    so the agent cannot authenticate at all. Capability, not cost.
+    # 2. On `synchronize` only, bot pushes are skipped: the fix loop commits once per
+    #    round and auditing each re-spends credits for no added signal. Scoped to
+    #    synchronize deliberately — a blanket bot exclusion would also stop auditing
+    #    PRs *opened* by Renovate, Copilot and release bots.
+    # 3. A label triggers an audit only when it is `agent:audit` (label.name is null
+    #    on open events, hence the action check first).
+    if: >-
+      github.actor != 'dependabot[bot]'
+      && (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
+      && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## The bug

Audit triggers were `[opened, reopened, labeled]` — **no `synchronize`**. So the cross-audits only ever graded a PR's *first* commit. Every fix pushed in response to a finding went ungraded, while the PR kept showing the original green.

A verdict about code that is no longer there is worse than no verdict at all, because it is indistinguishable from a real pass.

## This is not hypothetical — it happened here today

On #107:

1. Audit ran on `27e1161b`, reported no Blocking plus one Should-fix
2. I fixed that Should-fix in `0610ab3` and pushed
3. **No re-audit fired.** The PR still showed green, and the Codex comment still listed the issue I had just fixed
4. That mismatch is the only reason I looked. I was one command from merging

Re-running the audit at the real head then found a defect the stale pass **could not have seen**: the Builder prompt still told Claude `you have 25` turns while `--max-turns` had been raised to 40. A model paces itself against the stated figure, so it self-stops at 25 — silently defeating that PR's headline fix, in this repo and in every repo the template installs into.

## The fix

`synchronize` added to both auditors, live **and** template, with the guard that makes it affordable:

```yaml
github.actor != 'dependabot[bot]'
&& (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
&& (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
```

The bot skip is scoped to `synchronize` **deliberately**. The fix loop commits once per round and re-auditing each one re-spends credits for no new signal — but a blanket bot exclusion would also stop auditing PRs *opened* by Renovate, Copilot and release bots, which are among the changes most worth a second opinion.

Dependabot and `agent:audit` guards unchanged.

## Verification

Parsed all four files and asserted: `synchronize` in the trigger types, the bot skip scoped to `synchronize`, and the label + dependabot guards intact. Both template copies byte-identical to the live ones.

Worth recording: **the first run of this patch silently changed nothing.** Its idempotency check looked for the word `synchronize` anywhere in the file and found it in a comment, so it reported "already has synchronize, skipped" for all four. Caught only by validating the parsed result rather than trusting the patcher's own report — the same failure mode this PR exists to fix, one layer down.

`distil` received this fix earlier today; this brings compass and everything it seeds into line.
